### PR TITLE
feat: support repeating tasks when marking done

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A Neovim plugin inspired by [org-super-agenda](https://github.com/alphapapa/org-
 * **Right‑aligned tags**, customizable header format, and filename display
 * **Safety**: refuses edits when a swapfile is present or buffer is modified elsewhere
 * **Sticky DONE**: items marked DONE during the session remain visible until you close the window
+* **Repeat tasks**: repeating TODOs follow nvim-orgmode behavior when marked done (advance repeater dates, reset state, preserve repeat metadata)
 
 ---
 

--- a/doc/org-super-agenda.txt
+++ b/doc/org-super-agenda.txt
@@ -571,6 +571,8 @@ SAFETY NOTES                                                  *org-super-agenda-
 * Refuses edits if buffer is modified in Neovim or a swapfile is detected
 * DONE items set during the session remain visible in a dedicated group
   until the agenda window is closed ("sticky DONE")
+* Repeating TODOs follow nvim-orgmode behavior when marked done:
+  repeater dates advance, todo state resets, and repeat metadata is preserved
 * The catch‑all "Other" group never collects DONE items
 
 ===============================================================================

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -96,22 +96,68 @@ local function clock_goto_active()
 end
 
 -- === helpers: swap detection, buffer status, snapshots, safe writes ===
-local function has_swap_for(path)
-  -- Heuristic: look for .*{basename}*.sw?
-  local dir = vim.fn.fnamemodify(path, ':p:h')
-  local base = vim.fn.fnamemodify(path, ':t')
-  local patt = dir .. '/.*' .. vim.fn.escape(base, '[]^$\\.*') .. '.*.sw?'
-  return vim.fn.glob(patt) ~= ''
-end
-
 local function is_swap_error(err)
   local s = tostring(err or '')
   return s:find('Vim:E325', 1, true) ~= nil or s:find('E325:', 1, true) ~= nil
 end
 
+local function swap_glob_candidates(path)
+  local abs = vim.fn.fnamemodify(path, ':p')
+  local base = vim.fn.fnamemodify(abs, ':t')
+  local candidates = {}
+
+  local dir_entries = vim.opt.directory:get()
+  if type(dir_entries) ~= 'table' then
+    dir_entries = vim.split(vim.o.directory or '', ',', { plain = true, trimempty = true })
+  end
+
+  for _, entry in ipairs(dir_entries or {}) do
+    if entry and entry ~= '' and entry ~= '.' then
+      local expanded = vim.fn.expand(entry)
+      if expanded:sub(-2) == '//' then
+        local root = expanded:gsub('/+$', '')
+        local mangled = abs:gsub('[:/\\]', '%%')
+        candidates[#candidates + 1] = root .. '/' .. mangled .. '.sw?'
+      else
+        local root = expanded:gsub('/+$', '')
+        candidates[#candidates + 1] = root .. '/.' .. vim.fn.escape(base, '[]^$\\.*') .. '.*.sw?'
+      end
+    end
+  end
+
+  local local_dir = vim.fn.fnamemodify(abs, ':h')
+  candidates[#candidates + 1] = local_dir .. '/.' .. vim.fn.escape(base, '[]^$\\.*') .. '.*.sw?'
+  return candidates
+end
+
+local function has_swap_for(path)
+  for _, patt in ipairs(swap_glob_candidates(path)) do
+    if patt and patt ~= '' and vim.fn.glob(patt) ~= '' then
+      return true
+    end
+  end
+  return false
+end
+
 local function notify_swap_conflict(path, action)
   local short = vim.fn.fnamemodify(path or '', ':~:.')
-  vim.notify(string.format('%s blocked: swap-file conflict (E325) for %s. Resolve the swap/recovery prompt and try again.', action, short), vim.log.levels.WARN)
+  local msg = string.format('%s blocked: swap-file conflict (E325) for %s. Resolve the swap/recovery prompt and try again.', action, short)
+  vim.notify(msg, vim.log.levels.WARN, { title = 'org-super-agenda' })
+  pcall(vim.api.nvim_echo, { { msg, 'WarningMsg' } }, true, {})
+end
+
+local function notify_action_error(action, err, path)
+  if type(err) == 'table' and err.kind == 'swap_conflict' then
+    notify_swap_conflict(err.path or path, action)
+    return
+  end
+
+  if type(err) == 'string' and err:find('Detected a swap file', 1, true) then
+    notify_swap_conflict(path, action)
+    return
+  end
+
+  vim.notify(tostring(err), vim.log.levels.WARN, { title = 'org-super-agenda' })
 end
 
 local function buf_status_for(path)
@@ -377,12 +423,21 @@ end
 
 local function apply_heading_state_via_orgmode(hl, next_state)
   local todos = get_headline_todo_keywords(hl)
+  local path = (hl.file and hl.file.filename) or hl.filename
   local current_value = hl.todo_value or (hl._section and hl._section:get_todo()) or ''
   local current_kw = current_value ~= '' and todos and todos:find(current_value) or nil
   local target_kw = todos and todos:find(next_state) or nil
 
   if not todos or not current_kw or not target_kw then
     return false, 'Could not resolve orgmode todo state transition'
+  end
+
+  local st = buf_status_for(path)
+  if st.loaded and st.modified then
+    return false, 'File is open and modified in this Neovim; aborting to avoid data loss.'
+  end
+  if (not st.loaded) and has_swap_for(path) then
+    return false, { kind = 'swap_conflict', path = path }
   end
 
   local ok, result = pcall(function()
@@ -608,7 +663,7 @@ local function set_state_for_headline(line_map, next_state)
 
     local success, updated = apply_heading_state(hl, next_state)
     if not success then
-      vim.notify(updated, vim.log.levels.WARN)
+      notify_action_error('Set state', updated, hl.file and hl.file.filename)
       return
     end
 
@@ -864,7 +919,7 @@ local function bulk_action_menu(line_map)
           restores[#restores + 1] = make_restore_from_snapshot(snap)
           local ok3, updated = apply_heading_state(hl, next_state)
           if not ok3 then
-            vim.notify(updated, vim.log.levels.WARN)
+            notify_action_error('Bulk state change', updated, hl.file and hl.file.filename)
           else
             local key = key_for_hl(updated or hl)
             if updated and updated.todo_type == 'DONE' then
@@ -1467,7 +1522,7 @@ function A.set_keymaps(buf, win, line_map, reopen)
 
       local ok, updated = apply_heading_state(hl, next_state)
       if not ok then
-        vim.notify(updated, vim.log.levels.WARN)
+        notify_action_error('Cycle TODO', updated, hl.file and hl.file.filename)
         return
       end
 

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -424,6 +424,7 @@ end
 local function apply_heading_state_via_orgmode(hl, next_state)
   local todos = get_headline_todo_keywords(hl)
   local path = (hl.file and hl.file.filename) or hl.filename
+  local start_line = hl.position and hl.position.start_line or 1
   local current_value = hl.todo_value or (hl._section and hl._section:get_todo()) or ''
   local current_kw = current_value ~= '' and todos and todos:find(current_value) or nil
   local target_kw = todos and todos:find(next_state) or nil
@@ -440,77 +441,95 @@ local function apply_heading_state_via_orgmode(hl, next_state)
     return false, { kind = 'swap_conflict', path = path }
   end
 
-  local ok, result = pcall(function()
-    return hl:_do_action(function()
-      local org = require('orgmode')
-      local instance = org.instance()
-      local mappings = instance and instance.org_mappings
-      local current = instance and instance.files and instance.files:get_closest_headline()
-      if not current then
-        error('orgmode todo transition engine is unavailable', 0)
-      end
+  local function run_transition()
+    local org = require('orgmode')
+    local instance = org.instance()
+    local mappings = instance and instance.org_mappings
+    local current = instance and instance.files and instance.files:get_closest_headline()
+    if not current then
+      error('orgmode todo transition engine is unavailable', 0)
+    end
 
-      local old_state = current:get_todo()
-      local was_done = current:is_done()
-      current:set_todo(next_state)
+    local old_state = current:get_todo()
+    local was_done = current:is_done()
+    current:set_todo(next_state)
 
-      local item = instance.files:get_closest_headline()
-      local is_done = item:is_done() and not was_done
-      local is_undone = not item:is_done() and was_done
+    local item = instance.files:get_closest_headline()
+    local is_done = item:is_done() and not was_done
+    local is_undone = not item:is_done() and was_done
 
-      if not is_done and not is_undone then
-        return true
-      end
-
-      local org_config = require('orgmode.config')
-      local Date = require('orgmode.objects.date')
-      local TodoState = require('orgmode.objects.todo_state')
-      local repeater_dates = item:get_repeater_dates()
-
-      if #repeater_dates == 0 then
-        local log_closed_time = org_config.org_log_done == 'time'
-        if log_closed_time then
-          if is_done then
-            item:set_closed_date()
-          elseif is_undone then
-            item:remove_closed_date()
-          end
-        end
-        return true
-      end
-
-      if not (mappings and mappings._replace_date) then
-        error('orgmode repeater engine is unavailable', 0)
-      end
-
-      for _, date in ipairs(repeater_dates) do
-        mappings:_replace_date(date:apply_repeater())
-      end
-
-      item = instance.files:get_closest_headline()
-      local new_todo = item:get_todo()
-      local todo_state = TodoState:new({ current_state = new_todo, todos = item.file:get_todo_keywords() })
-      local reset_keyword = todo_state:get_reset_todo(item, old_state)
-      item:set_todo(reset_keyword.value)
-
-      local log_repeat_enabled = org_config.org_log_repeat ~= false
-      local prompt_repeat_note = org_config.org_log_repeat == 'note'
-      local prompt_done_note = org_config.org_log_done == 'note'
-      if log_repeat_enabled then
-        item:set_property('LAST_REPEAT', Date.now():to_wrapped_string(false))
-        if not prompt_repeat_note and not prompt_done_note then
-          local indent = item:get_indent()
-          local repeat_note_template = ('%s- State %-12s from %-12s [%s]'):format(
-            indent,
-            [["]] .. (new_todo or '') .. [["]],
-            [["]] .. (old_state or '') .. [["]],
-            Date.now():to_string()
-          )
-          item:add_note({ repeat_note_template })
-        end
-      end
-
+    if not is_done and not is_undone then
       return true
+    end
+
+    local org_config = require('orgmode.config')
+    local Date = require('orgmode.objects.date')
+    local TodoState = require('orgmode.objects.todo_state')
+    local repeater_dates = item:get_repeater_dates()
+
+    if #repeater_dates == 0 then
+      local log_closed_time = org_config.org_log_done == 'time'
+      if log_closed_time then
+        if is_done then
+          item:set_closed_date()
+        elseif is_undone then
+          item:remove_closed_date()
+        end
+      end
+      return true
+    end
+
+    if not (mappings and mappings._replace_date) then
+      error('orgmode repeater engine is unavailable', 0)
+    end
+
+    for _, date in ipairs(repeater_dates) do
+      mappings:_replace_date(date:apply_repeater())
+    end
+
+    item = instance.files:get_closest_headline()
+    local new_todo = item:get_todo()
+    local todo_state = TodoState:new({ current_state = new_todo, todos = item.file:get_todo_keywords() })
+    local reset_keyword = todo_state:get_reset_todo(item, old_state)
+    item:set_todo(reset_keyword.value)
+
+    local log_repeat_enabled = org_config.org_log_repeat ~= false
+    local prompt_repeat_note = org_config.org_log_repeat == 'note'
+    local prompt_done_note = org_config.org_log_done == 'note'
+    if log_repeat_enabled then
+      item:set_property('LAST_REPEAT', Date.now():to_wrapped_string(false))
+      if not prompt_repeat_note and not prompt_done_note then
+        local indent = item:get_indent()
+        local repeat_note_template = ('%s- State %-12s from %-12s [%s]'):format(
+          indent,
+          [["]] .. (new_todo or '') .. [["]],
+          [["]] .. (old_state or '') .. [["]],
+          Date.now():to_string()
+        )
+        item:add_note({ repeat_note_template })
+      end
+    end
+
+    return true
+  end
+
+  local ok, result = pcall(function()
+    if st.loaded then
+      return vim.api.nvim_buf_call(st.bufnr, function()
+        local view = vim.fn.winsaveview() or {}
+        vim.fn.cursor({ start_line, 1 })
+        run_transition()
+        vim.cmd('silent noautocmd write')
+        vim.fn.winrestview(view)
+        local ok_reload, reloaded = pcall(function()
+          return hl:reload()
+        end)
+        return ok_reload and reloaded or hl
+      end)
+    end
+
+    return hl:_do_action(function()
+      return run_transition()
     end):wait(20000)
   end)
 
@@ -751,6 +770,55 @@ local function find_stamp_near(path, start_line, keyword)
     end
   end
   return nil
+end
+
+local function open_loaded_datepicker(hl, keyword, bufnr)
+  local Calendar = require('orgmode.objects.calendar')
+  local Date = require('orgmode.objects.date')
+
+  local get_date = keyword == 'SCHEDULED' and 'get_scheduled_date' or 'get_deadline_date'
+  local set_date = keyword == 'SCHEDULED' and 'set_scheduled_date' or 'set_deadline_date'
+  local remove_date = keyword == 'SCHEDULED' and 'remove_scheduled_date' or 'remove_deadline_date'
+  local title = keyword == 'SCHEDULED' and 'Set schedule' or 'Set deadline'
+  local initial = hl._section and hl._section[get_date] and hl._section[get_date](hl._section) or Date.today()
+
+  return Calendar.new({ date = initial, clearable = true, title = title }):open():next(function(new_date, cleared)
+    if not new_date and not cleared then
+      return
+    end
+
+    return vim.api.nvim_buf_call(bufnr, function()
+      local view = vim.fn.winsaveview() or {}
+      vim.fn.cursor({ hl.position.start_line, 1 })
+
+      local org = require('orgmode')
+      local item = org.instance().files:get_closest_headline()
+      if not item then
+        error('orgmode date change target is unavailable', 0)
+      end
+
+      if cleared then
+        item[remove_date](item)
+      else
+        item[set_date](item, new_date)
+      end
+
+      vim.cmd('silent noautocmd write')
+      vim.fn.winrestview(view)
+      return true
+    end)
+  end)
+end
+
+local function open_headline_datepicker(hl, keyword)
+  local st = buf_status_for(hl.file.filename)
+  if st.loaded then
+    return open_loaded_datepicker(hl, keyword, st.bufnr)
+  end
+  if keyword == 'SCHEDULED' then
+    return hl:set_scheduled()
+  end
+  return hl:set_deadline()
 end
 
 -- Apply a date bulk-op: open datepicker on first_hl, then mirror result to all targets.
@@ -1017,12 +1085,12 @@ local function bulk_action_menu(line_map)
       elseif choice.key == 'r' then
         -- bulk reschedule: prompt once via first item, apply result to all
         bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
-          return hl:set_scheduled()
+          return open_headline_datepicker(hl, 'SCHEDULED')
         end)
       elseif choice.key == 'd' then
         -- bulk deadline: same pattern
         bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
-          return hl:set_deadline()
+          return open_headline_datepicker(hl, 'DEADLINE')
         end)
       end
     end)
@@ -1049,12 +1117,12 @@ local function bulk_action_menu(line_map)
     elseif c == 'r' then
       -- bulk reschedule: prompt once via first item, apply result to all
       bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
-        return hl:set_scheduled()
+        return open_headline_datepicker(hl, 'SCHEDULED')
       end)
     elseif c == 'd' then
       -- bulk deadline: same pattern
       bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
-        return hl:set_deadline()
+        return open_headline_datepicker(hl, 'DEADLINE')
       end)
     end
   end
@@ -1167,7 +1235,7 @@ function A.set_keymaps(buf, win, line_map, reopen)
       end
       local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(path, hl.position.start_line)
       local ok_p, p = pcall(function()
-        return hl:set_scheduled()
+        return open_headline_datepicker(hl, 'SCHEDULED')
       end)
       if not ok_p then
         if is_swap_error(p) then
@@ -1199,7 +1267,7 @@ function A.set_keymaps(buf, win, line_map, reopen)
       end
       local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(path, hl.position.start_line)
       local ok_p, p = pcall(function()
-        return hl:set_deadline()
+        return open_headline_datepicker(hl, 'DEADLINE')
       end)
       if not ok_p then
         if is_swap_error(p) then

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -345,6 +345,147 @@ local function safe_set_heading_state(hl, next_state)
   end
 end
 
+local function get_headline_todo_keywords(hl)
+  local section = hl and hl._section
+  local file = section and section.file
+  if not (file and file.get_todo_keywords) then
+    return nil
+  end
+  return file:get_todo_keywords()
+end
+
+local function should_use_orgmode_state_transition(hl, next_state)
+  if not hl or next_state == '' then
+    return false
+  end
+
+  local todos = get_headline_todo_keywords(hl)
+  if not todos then
+    return false
+  end
+
+  local current_value = hl.todo_value or (hl._section and hl._section:get_todo()) or ''
+  local current_kw = current_value ~= '' and todos:find(current_value) or nil
+  local target_kw = todos:find(next_state)
+
+  if not current_kw or not target_kw then
+    return false
+  end
+
+  return current_kw.sequence_index == target_kw.sequence_index and current_kw.type ~= target_kw.type
+end
+
+local function apply_heading_state_via_orgmode(hl, next_state)
+  local todos = get_headline_todo_keywords(hl)
+  local current_value = hl.todo_value or (hl._section and hl._section:get_todo()) or ''
+  local current_kw = current_value ~= '' and todos and todos:find(current_value) or nil
+  local target_kw = todos and todos:find(next_state) or nil
+
+  if not todos or not current_kw or not target_kw then
+    return false, 'Could not resolve orgmode todo state transition'
+  end
+
+  local ok, result = pcall(function()
+    return hl:_do_action(function()
+      local org = require('orgmode')
+      local instance = org.instance()
+      local mappings = instance and instance.org_mappings
+      local current = instance and instance.files and instance.files:get_closest_headline()
+      if not current then
+        error('orgmode todo transition engine is unavailable', 0)
+      end
+
+      local old_state = current:get_todo()
+      local was_done = current:is_done()
+      current:set_todo(next_state)
+
+      local item = instance.files:get_closest_headline()
+      local is_done = item:is_done() and not was_done
+      local is_undone = not item:is_done() and was_done
+
+      if not is_done and not is_undone then
+        return true
+      end
+
+      local org_config = require('orgmode.config')
+      local Date = require('orgmode.objects.date')
+      local TodoState = require('orgmode.objects.todo_state')
+      local repeater_dates = item:get_repeater_dates()
+
+      if #repeater_dates == 0 then
+        local log_closed_time = org_config.org_log_done == 'time'
+        if log_closed_time then
+          if is_done then
+            item:set_closed_date()
+          elseif is_undone then
+            item:remove_closed_date()
+          end
+        end
+        return true
+      end
+
+      if not (mappings and mappings._replace_date) then
+        error('orgmode repeater engine is unavailable', 0)
+      end
+
+      for _, date in ipairs(repeater_dates) do
+        mappings:_replace_date(date:apply_repeater())
+      end
+
+      item = instance.files:get_closest_headline()
+      local new_todo = item:get_todo()
+      local todo_state = TodoState:new({ current_state = new_todo, todos = item.file:get_todo_keywords() })
+      local reset_keyword = todo_state:get_reset_todo(item, old_state)
+      item:set_todo(reset_keyword.value)
+
+      local log_repeat_enabled = org_config.org_log_repeat ~= false
+      local prompt_repeat_note = org_config.org_log_repeat == 'note'
+      local prompt_done_note = org_config.org_log_done == 'note'
+      if log_repeat_enabled then
+        item:set_property('LAST_REPEAT', Date.now():to_wrapped_string(false))
+        if not prompt_repeat_note and not prompt_done_note then
+          local indent = item:get_indent()
+          local repeat_note_template = ('%s- State %-12s from %-12s [%s]'):format(
+            indent,
+            [["]] .. (new_todo or '') .. [["]],
+            [["]] .. (old_state or '') .. [["]],
+            Date.now():to_string()
+          )
+          item:add_note({ repeat_note_template })
+        end
+      end
+
+      return true
+    end):wait(20000)
+  end)
+
+  if not ok then
+    return false, tostring(result)
+  end
+
+  return true, result
+end
+
+local function apply_heading_state(hl, next_state)
+  if should_use_orgmode_state_transition(hl, next_state) then
+    return apply_heading_state_via_orgmode(hl, next_state)
+  end
+
+  local ok, err = safe_set_heading_state(hl, next_state)
+  if not ok then
+    return false, err
+  end
+
+  local reload_ok, reloaded = pcall(function()
+    return hl:reload()
+  end)
+  if reload_ok and reloaded then
+    return true, reloaded
+  end
+
+  return true, hl
+end
+
 -- === headline toolbelt ===
 local function with_headline(line_map, cb)
   local cur = vim.api.nvim_win_get_cursor(0)
@@ -465,14 +606,14 @@ local function set_state_for_headline(line_map, next_state)
     local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl.file.filename, hl.position.start_line)
     Store.push_undo(make_restore_from_snapshot(snap))
 
-    local success, err = safe_set_heading_state(hl, next_state)
+    local success, updated = apply_heading_state(hl, next_state)
     if not success then
-      vim.notify(err, vim.log.levels.WARN)
+      vim.notify(updated, vim.log.levels.WARN)
       return
     end
 
-    local key = key_for_hl(hl)
-    if next_state == 'DONE' then
+    local key = key_for_hl(updated)
+    if updated.todo_type == 'DONE' then
       Store.sticky_add(key)
     else
       Store.sticky_remove(key)
@@ -721,15 +862,16 @@ local function bulk_action_menu(line_map)
           local st = buf_status_for(hl_fname)
           local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl_fname, hl_start_line(hl))
           restores[#restores + 1] = make_restore_from_snapshot(snap)
-          local ok3, err = safe_set_heading_state(hl, next_state)
+          local ok3, updated = apply_heading_state(hl, next_state)
           if not ok3 then
-            vim.notify(err, vim.log.levels.WARN)
-          end
-          local key = key_for_hl(hl)
-          if next_state == 'DONE' then
-            Store.sticky_add(key)
+            vim.notify(updated, vim.log.levels.WARN)
           else
-            Store.sticky_remove(key)
+            local key = key_for_hl(updated or hl)
+            if updated and updated.todo_type == 'DONE' then
+              Store.sticky_add(key)
+            else
+              Store.sticky_remove(key)
+            end
           end
         end
       end
@@ -1323,14 +1465,14 @@ function A.set_keymaps(buf, win, line_map, reopen)
       local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl.file.filename, hl.position.start_line)
       Store.push_undo(make_restore_from_snapshot(snap))
 
-      local ok, err = safe_set_heading_state(hl, next_state)
+      local ok, updated = apply_heading_state(hl, next_state)
       if not ok then
-        vim.notify(err, vim.log.levels.WARN)
+        vim.notify(updated, vim.log.levels.WARN)
         return
       end
 
-      local key = key_for_hl(hl)
-      if next_state == 'DONE' then
+      local key = key_for_hl(updated)
+      if updated.todo_type == 'DONE' then
         Store.sticky_add(key)
       else
         Store.sticky_remove(key)

--- a/tests/repeat_tasks_spec.lua
+++ b/tests/repeat_tasks_spec.lua
@@ -1,0 +1,291 @@
+local Actions = require('org-super-agenda.adapters.neovim.actions')
+local Store = require('org-super-agenda.app.store')
+local Services = require('org-super-agenda.app.services')
+local config = require('org-super-agenda.config')
+
+describe('repeat task support', function()
+  local original_state
+  local original_refresh
+  local original_notify
+  local original_loaded = {}
+  local temp_files = {}
+  local refresh_calls = 0
+  local notifications = {}
+
+  local module_names = {
+    'orgmode',
+    'orgmode.api',
+    'orgmode.config',
+    'orgmode.objects.date',
+    'orgmode.objects.todo_state',
+  }
+
+  local function write_temp_org(lines)
+    local path = vim.fn.tempname() .. '.org'
+    vim.fn.writefile(lines, path)
+    temp_files[#temp_files + 1] = path
+    return path
+  end
+
+  local function setup_agenda_buffer(path)
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_win_set_buf(0, buf)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'agenda row' })
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    Actions.set_keymaps(buf, vim.api.nvim_get_current_win(), { [1] = { file = path, _src_line = 1 } }, function() end)
+    return buf
+  end
+
+  local function invoke_buffer_mapping(lhs)
+    local map = vim.fn.maparg(lhs, 'n', false, true)
+    assert.is_truthy(map)
+    assert.is_truthy(map.callback)
+    map.callback()
+  end
+
+  local function setup_fake_org(opts)
+    local path = opts.path
+    local todo = opts.todo or 'TODO'
+    local replaced = {}
+
+    local kw_todo = { value = 'TODO', type = 'TODO', index = 1, sequence_index = 1 }
+    local kw_done = { value = 'DONE', type = 'DONE', index = 2, sequence_index = 1 }
+    local todo_keywords = {
+      find = function(_, value)
+        if value == 'TODO' then
+          return kw_todo
+        end
+        if value == 'DONE' then
+          return kw_done
+        end
+      end,
+      all = function()
+        return { kw_todo, kw_done }
+      end,
+    }
+
+    local internal_file = {
+      filename = path,
+      get_todo_keywords = function()
+        return todo_keywords
+      end,
+    }
+
+    local internal = {
+      file = internal_file,
+      todo = todo,
+      properties = {},
+      notes = {},
+      repeater_dates = opts.repeater_dates or {},
+      closed_set = false,
+      get_todo = function(self)
+        return self.todo
+      end,
+      is_done = function(self)
+        return self.todo == 'DONE'
+      end,
+      set_todo = function(self, keyword)
+        self.todo = keyword
+      end,
+      get_repeater_dates = function(self)
+        return self.repeater_dates
+      end,
+      set_closed_date = function(self)
+        self.closed_set = true
+      end,
+      remove_closed_date = function(self)
+        self.closed_set = false
+      end,
+      set_property = function(self, key, value)
+        self.properties[key] = value
+      end,
+      add_note = function(self, note)
+        table.insert(self.notes, note)
+      end,
+      get_indent = function()
+        return ''
+      end,
+    }
+
+    local api_headline = {
+      file = { filename = path },
+      position = { start_line = 1, end_line = 1 },
+      todo_value = todo,
+      todo_type = todo_keywords:find(todo).type,
+      properties = {},
+      _section = internal,
+    }
+
+    function api_headline:reload()
+      self.todo_value = internal:get_todo()
+      local kw = todo_keywords:find(self.todo_value)
+      self.todo_type = kw and kw.type or ''
+      self.properties = vim.deepcopy(internal.properties)
+      return self
+    end
+
+    function api_headline:_do_action(action)
+      return {
+        wait = function()
+          action()
+          return self:reload()
+        end,
+      }
+    end
+
+    local fake_instance = {
+      files = {
+        get_closest_headline = function()
+          return internal
+        end,
+      },
+      org_mappings = {
+        _replace_date = function(_, date)
+          table.insert(replaced, date.kind)
+        end,
+      },
+    }
+
+    package.loaded['orgmode'] = {
+      instance = function()
+        return fake_instance
+      end,
+    }
+
+    package.loaded['orgmode.api'] = {
+      load = function(requested)
+        if requested == path then
+          return {
+            get_headline_on_line = function(_, line)
+              if line == 1 then
+                return api_headline
+              end
+            end,
+          }
+        end
+        return {}
+      end,
+      org = {},
+    }
+
+    package.loaded['orgmode.config'] = {
+      org_log_repeat = true,
+      org_log_done = 'time',
+    }
+
+    package.loaded['orgmode.objects.date'] = {
+      now = function()
+        return {
+          to_wrapped_string = function()
+            return '[2026-04-11 Fri 12:00]'
+          end,
+          to_string = function()
+            return '2026-04-11 Fri 12:00'
+          end,
+        }
+      end,
+    }
+
+    package.loaded['orgmode.objects.todo_state'] = {
+      new = function(_, _)
+        return {
+          get_reset_todo = function()
+            return kw_todo
+          end,
+        }
+      end,
+    }
+
+    return {
+      api_headline = api_headline,
+      internal = internal,
+      replaced = replaced,
+    }
+  end
+
+  before_each(function()
+    original_state = vim.deepcopy(Store.state)
+    original_refresh = Services.agenda.refresh
+    original_notify = vim.notify
+    refresh_calls = 0
+    notifications = {}
+    temp_files = {}
+
+    for _, name in ipairs(module_names) do
+      original_loaded[name] = package.loaded[name]
+    end
+
+    Services.agenda.refresh = function()
+      refresh_calls = refresh_calls + 1
+    end
+    vim.notify = function(msg)
+      notifications[#notifications + 1] = msg
+    end
+
+    Store.state = vim.deepcopy(original_state)
+    config.setup(vim.deepcopy(config.defaults))
+  end)
+
+  after_each(function()
+    Services.agenda.refresh = original_refresh
+    vim.notify = original_notify
+    Store.state = vim.deepcopy(original_state)
+    config.setup(vim.deepcopy(config.defaults))
+
+    for _, name in ipairs(module_names) do
+      package.loaded[name] = original_loaded[name]
+    end
+
+    for _, path in ipairs(temp_files) do
+      pcall(vim.fn.delete, path)
+    end
+  end)
+
+  it('advances repeater metadata and resets to TODO when marking a repeating task done', function()
+    local path = write_temp_org({ '* TODO Weekly review' })
+    local env = setup_fake_org({
+      path = path,
+      repeater_dates = {
+        {
+          kind = 'scheduled',
+          apply_repeater = function(self)
+            return { kind = self.kind }
+          end,
+        },
+        {
+          kind = 'deadline',
+          apply_repeater = function(self)
+            return { kind = self.kind }
+          end,
+        },
+      },
+    })
+
+    setup_agenda_buffer(path)
+    invoke_buffer_mapping('sd')
+
+    assert.are.same({ 'scheduled', 'deadline' }, env.replaced)
+    assert.equals('TODO', env.internal.todo)
+    assert.equals('[2026-04-11 Fri 12:00]', env.internal.properties.LAST_REPEAT)
+    assert.equals(1, #env.internal.notes)
+    assert.is_true(env.internal.notes[1][1]:find('State ') ~= nil)
+    assert.is_false(Store.sticky_has(path .. ':1'))
+    assert.equals(1, refresh_calls)
+    assert.are.same({}, notifications)
+  end)
+
+  it('keeps non-repeating tasks as DONE and records sticky state', function()
+    local path = write_temp_org({ '* TODO One-off task' })
+    local env = setup_fake_org({ path = path, repeater_dates = {} })
+
+    setup_agenda_buffer(path)
+    invoke_buffer_mapping('sd')
+
+    assert.are.same({}, env.replaced)
+    assert.equals('DONE', env.internal.todo)
+    assert.is_true(env.internal.closed_set)
+    assert.is_true(Store.sticky_has(path .. ':1'))
+    assert.equals(1, refresh_calls)
+    assert.are.same({}, notifications)
+  end)
+end)


### PR DESCRIPTION
Route todo state changes that cross the TODO/DONE boundary through orgmode-aware repeater handling so scheduled and deadline repeaters advance, states reset correctly, and repeat metadata is preserved.

## What does this PR do?

<!-- A short description of the change and why it's needed -->

## Type

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Docs / refactor

## Notes

<!-- Anything the reviewer should know: edge cases, related issues, testing notes -->

Fixes #20 
