### PR TITLE
feat!: use nvim-orgmode org_agenda_files as source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ return {
       show_other_group   = false,     -- show catch-all section
       show_tags          = true,      -- draw tags on the right
       show_filename      = true,      -- include [filename]
+      bulk_action_prompt = 'keys',    -- 'keys' (fast keypress) | 'select' (vim.ui.select / noice-friendly)
       heading_max_length = 70,
       persist_hidden     = false,     -- keep hidden items across reopen
       view_mode          = 'classic', -- 'classic' | 'compact'

--- a/README.md
+++ b/README.md
@@ -64,10 +64,15 @@ return {
     { 'lukas-reineke/headlines.nvim', config = true }, -- optional nicety
   },
   config = function()
+    -- First configure nvim-orgmode with your agenda files
+    require('orgmode').setup({
+      org_agenda_files = {'~/org/**/*', '~/work/**/*.org'},
+      -- ... other orgmode config
+    })
+
+    -- org-super-agenda will automatically use orgmode's org_agenda_files
     require('org-super-agenda').setup({
-      -- Where to look for .org files
-      org_files           = {},
-      org_directories     = {}, -- recurse for *.org
+      -- Optional: exclude specific files or directories from the agenda
       exclude_files       = {},
       exclude_directories = {},
 

--- a/doc/org-super-agenda.txt
+++ b/doc/org-super-agenda.txt
@@ -519,6 +519,7 @@ M.defaults = {
   show_other_group    = false,
   show_tags           = true,
   show_filename       = true,
+  bulk_action_prompt  = 'keys', -- 'keys' | 'select'
   heading_max_length  = 70,
   persist_hidden      = false,
   fold_item_action    = 'preview',  -- 'preview' or 'goto'

--- a/doc/org-super-agenda.txt
+++ b/doc/org-super-agenda.txt
@@ -59,11 +59,19 @@ Call |lua| to setup the plugin:
 lua << EOF
 ```
 
+First configure nvim-orgmode with your agenda files:
+```
+require('orgmode').setup({
+  org_agenda_files = {'~/org/**/*', '~/work/**/*.org'},
+  -- ... other orgmode config
+})
+```
+
+org-super-agenda will automatically use orgmode's org_agenda_files:
 ```
 require('org-super-agenda').setup({
-  org_directories     = {},        -- recurse for *.org files
-  exclude_files       = {},        -- files to ignore
-  exclude_directories = {},        -- directories to ignore
+  exclude_files       = {},        -- optional: files to ignore
+  exclude_directories = {},        -- optional: directories to ignore
   -- additional options are documented below and in the source
 })
 EOF
@@ -397,8 +405,6 @@ The defaults (see |lua/org-super-agenda/config.lua|) are:
 
 >
 M.defaults = {
-  org_files           = {},
-  org_directories     = {},
   exclude_files       = {},
   exclude_directories = {},
   keymaps             = {

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -104,6 +104,16 @@ local function has_swap_for(path)
   return vim.fn.glob(patt) ~= ''
 end
 
+local function is_swap_error(err)
+  local s = tostring(err or '')
+  return s:find('Vim:E325', 1, true) ~= nil or s:find('E325:', 1, true) ~= nil
+end
+
+local function notify_swap_conflict(path, action)
+  local short = vim.fn.fnamemodify(path or '', ':~:.')
+  vim.notify(string.format('%s blocked: swap-file conflict (E325) for %s. Resolve the swap/recovery prompt and try again.', action, short), vim.log.levels.WARN)
+end
+
 local function buf_status_for(path)
   local bufnr = vim.fn.bufnr(path)
   if bufnr == -1 then
@@ -561,12 +571,22 @@ local function bulk_apply_date(targets, cur, first_hl, snap_first, keyword, open
     return
   end
 
+  local st0 = buf_status_for(fname)
+  if (not st0.loaded) and has_swap_for(fname) then
+    notify_swap_conflict(fname, keyword)
+    return
+  end
+
   -- read planning stamp BEFORE the picker runs (to detect removal afterwards)
   local before_stamp = find_stamp_near(fname, start_l, keyword)
 
   local ok_p, p = pcall(open_picker, first_hl)
   if not ok_p then
-    vim.notify('Could not open datepicker: ' .. tostring(p), vim.log.levels.WARN)
+    if is_swap_error(p) then
+      notify_swap_conflict(fname, keyword)
+    else
+      vim.notify('Could not open datepicker: ' .. tostring(p), vim.log.levels.WARN)
+    end
     return
   end
 
@@ -942,9 +962,24 @@ function A.set_keymaps(buf, win, line_map, reopen)
   -- reschedule / deadline (unchanged but undo-aware)
   vim.keymap.set('n', cfg.keymaps.reschedule, function()
     with_headline(line_map, function(cur, hl)
-      local st = buf_status_for(hl.file.filename)
-      local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl.file.filename, hl.position.start_line)
-      local p = hl:set_scheduled()
+      local path = hl.file.filename
+      local st = buf_status_for(path)
+      if (not st.loaded) and has_swap_for(path) then
+        notify_swap_conflict(path, 'Reschedule')
+        return
+      end
+      local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(path, hl.position.start_line)
+      local ok_p, p = pcall(function()
+        return hl:set_scheduled()
+      end)
+      if not ok_p then
+        if is_swap_error(p) then
+          notify_swap_conflict(path, 'Reschedule')
+        else
+          vim.notify('Could not open datepicker: ' .. tostring(p), vim.log.levels.WARN)
+        end
+        return
+      end
       local function after()
         Store.push_undo(make_restore_from_snapshot(snap))
         Services.agenda.refresh(cur)
@@ -959,9 +994,24 @@ function A.set_keymaps(buf, win, line_map, reopen)
 
   vim.keymap.set('n', cfg.keymaps.set_deadline, function()
     with_headline(line_map, function(cur, hl)
-      local st = buf_status_for(hl.file.filename)
-      local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl.file.filename, hl.position.start_line)
-      local p = hl:set_deadline()
+      local path = hl.file.filename
+      local st = buf_status_for(path)
+      if (not st.loaded) and has_swap_for(path) then
+        notify_swap_conflict(path, 'Set deadline')
+        return
+      end
+      local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(path, hl.position.start_line)
+      local ok_p, p = pcall(function()
+        return hl:set_deadline()
+      end)
+      if not ok_p then
+        if is_swap_error(p) then
+          notify_swap_conflict(path, 'Set deadline')
+        else
+          vim.notify('Could not open datepicker: ' .. tostring(p), vim.log.levels.WARN)
+        end
+        return
+      end
       local function after()
         Store.push_undo(make_restore_from_snapshot(snap))
         Services.agenda.refresh(cur)

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -799,7 +799,10 @@ function A.set_keymaps(buf, win, line_map, reopen)
       -- Popup mode: detach from tmux session to hide the popup
       vim.fn.system(popup.hide_command)
     else
-      -- Normal mode: close buffer
+      -- Normal mode: close window + buffer
+      if vim.api.nvim_win_is_valid(win) then
+        pcall(vim.api.nvim_win_close, win, true)
+      end
       if vim.api.nvim_buf_is_valid(buf) then
         pcall(vim.api.nvim_buf_delete, buf, { force = true })
       end

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -682,62 +682,7 @@ local function bulk_action_menu(line_map)
     end
   end
 
-  local count = #targets
-  local chunks = {
-    { 'Bulk (' .. count .. '): ', 'Normal' },
-    { 's', 'Comment' },
-    { '=state  ', 'Normal' },
-    { 'r', 'Comment' },
-    { '=reschedule  ', 'Normal' },
-    { 'd', 'Comment' },
-    { '=deadline', 'Normal' },
-  }
-  vim.api.nvim_echo(chunks, false, {})
-  local ok, c = pcall(vim.fn.getcharstr)
-  vim.api.nvim_echo({}, false, {})
-  if not ok then
-    return
-  end
-
-  local cur = vim.api.nvim_win_get_cursor(0)
-
-  if c == 's' then
-    -- bulk TODO state
-    local seq = {}
-    for _, s in ipairs(get_cfg().todo_states or {}) do
-      seq[#seq + 1] = s.name
-    end
-    if #seq == 0 then
-      return
-    end
-    local shortcuts, _ = build_state_shortcuts(get_cfg().todo_states or {})
-    local sch = { { '0', 'Comment' }, { '=clear  ', 'Normal' } }
-    for _, s in ipairs(shortcuts) do
-      sch[#sch + 1] = { s.key, 'Comment' }
-      sch[#sch + 1] = { '=' .. s.name .. '  ', 'Normal' }
-    end
-    vim.api.nvim_echo(sch, false, {})
-    local ok2, c2 = pcall(vim.fn.getcharstr)
-    vim.api.nvim_echo({}, false, {})
-    if not ok2 then
-      return
-    end
-
-    local next_state
-    if c2 == '0' then
-      next_state = ''
-    else
-      for _, s in ipairs(shortcuts) do
-        if s.key == c2 then
-          next_state = s.name
-          break
-        end
-      end
-    end
-    if next_state == nil then
-      return
-    end
-
+  local function apply_bulk_state(next_state, cur)
     local restores = {}
     for _, it in ipairs(targets) do
       local hl_ok, api_root = pcall(require, 'orgmode.api')
@@ -772,16 +717,129 @@ local function bulk_action_menu(line_map)
     push_bulk_undo(restores)
     Store.mark_clear()
     Services.agenda.refresh(cur)
-  elseif c == 'r' then
-    -- bulk reschedule: prompt once via first item, apply result to all
-    bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
-      return hl:set_scheduled()
+  end
+
+  local function choose_bulk_state_select(cur)
+    local shortcuts, _ = build_state_shortcuts(get_cfg().todo_states or {})
+    if #shortcuts == 0 then
+      return
+    end
+    local options = { { key = '0', name = 'clear' } }
+    for _, s in ipairs(shortcuts) do
+      options[#options + 1] = { key = s.key, name = s.name }
+    end
+    vim.ui.select(options, {
+      prompt = 'Bulk state:',
+      format_item = function(item)
+        return string.format('%s = %s', item.key, item.name)
+      end,
+    }, function(choice)
+      if not choice then
+        return
+      end
+      local next_state = (choice.key == '0') and '' or choice.name
+      apply_bulk_state(next_state, cur)
     end)
-  elseif c == 'd' then
-    -- bulk deadline: same pattern
-    bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
-      return hl:set_deadline()
+  end
+
+  local function choose_bulk_state_keys(cur)
+    local shortcuts, _ = build_state_shortcuts(get_cfg().todo_states or {})
+    if #shortcuts == 0 then
+      return
+    end
+    local sch = { { '0', 'Comment' }, { '=clear  ', 'Normal' } }
+    for _, s in ipairs(shortcuts) do
+      sch[#sch + 1] = { s.key, 'Comment' }
+      sch[#sch + 1] = { '=' .. s.name .. '  ', 'Normal' }
+    end
+    vim.api.nvim_echo(sch, false, {})
+    local ok2, c2 = pcall(vim.fn.getcharstr)
+    vim.api.nvim_echo({}, false, {})
+    if not ok2 then
+      return
+    end
+
+    local next_state
+    if c2 == '0' then
+      next_state = ''
+    else
+      for _, s in ipairs(shortcuts) do
+        if s.key == c2 then
+          next_state = s.name
+          break
+        end
+      end
+    end
+    if next_state == nil then
+      return
+    end
+    apply_bulk_state(next_state, cur)
+  end
+
+  local count = #targets
+  local mode = (get_cfg().bulk_action_prompt == 'select') and 'select' or 'keys'
+
+  if mode == 'select' then
+    local actions = {
+      { key = 's', label = 'set state' },
+      { key = 'r', label = 'reschedule' },
+      { key = 'd', label = 'deadline' },
+    }
+    vim.ui.select(actions, {
+      prompt = string.format('Bulk (%d) action:', count),
+      format_item = function(item)
+        return string.format('%s = %s', item.key, item.label)
+      end,
+    }, function(choice)
+      if not choice then
+        return
+      end
+      local cur = vim.api.nvim_win_get_cursor(0)
+      if choice.key == 's' then
+        choose_bulk_state_select(cur)
+      elseif choice.key == 'r' then
+        -- bulk reschedule: prompt once via first item, apply result to all
+        bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
+          return hl:set_scheduled()
+        end)
+      elseif choice.key == 'd' then
+        -- bulk deadline: same pattern
+        bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
+          return hl:set_deadline()
+        end)
+      end
     end)
+  else
+    local chunks = {
+      { 'Bulk (' .. count .. '): ', 'Normal' },
+      { 's', 'Comment' },
+      { '=state  ', 'Normal' },
+      { 'r', 'Comment' },
+      { '=reschedule  ', 'Normal' },
+      { 'd', 'Comment' },
+      { '=deadline', 'Normal' },
+    }
+    vim.api.nvim_echo(chunks, false, {})
+    local ok, c = pcall(vim.fn.getcharstr)
+    vim.api.nvim_echo({}, false, {})
+    if not ok then
+      return
+    end
+
+    local cur = vim.api.nvim_win_get_cursor(0)
+    if c == 's' then
+      choose_bulk_state_keys(cur)
+    elseif c == 'r' then
+      -- bulk reschedule: prompt once via first item, apply result to all
+      bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
+        return hl:set_scheduled()
+      end)
+    elseif c == 'd' then
+      -- bulk deadline: same pattern
+      bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
+        return hl:set_deadline()
+      end)
+    end
   end
 end
 

--- a/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
+++ b/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
@@ -6,60 +6,52 @@ local Item = require('org-super-agenda.core.item')
 
 local S = {}
 
--- Utility: expand directories/files declared in config and load orgmode files
+-- Load all org files directly from nvim-orgmode (respects org_agenda_files)
 local function load_org_files()
   local C = cfg()
-  local want, skip = {}, {}
-  local function add(tbl, k)
-    if k and k ~= '' then
-      tbl[utils.expand(k)] = true
-    end
+
+  local ok_api, org_api = pcall(require, 'orgmode.api')
+  if not ok_api or not org_api or not org_api.load then
+    error('nvim-orgmode is required but not found. Please install nvim-orgmode/orgmode')
   end
 
-  for _, f in ipairs(C.org_files or {}) do
-    add(want, f)
+  -- orgmode.api.load() with no args returns all agenda files already resolved
+  local ok, all_files = pcall(org_api.load)
+  if not ok or not all_files then
+    return {}
   end
-  for _, d in ipairs(C.org_directories or {}) do
-    for _, f in ipairs(utils.get_org_files(d)) do
-      add(want, f)
-    end
-  end
+
+  -- Build exclusion set
+  local skip = {}
   for _, f in ipairs(C.exclude_files or {}) do
-    add(skip, f)
-  end
-  for _, d in ipairs(C.exclude_directories or {}) do
-    for p in pairs(want) do
-      if p:find('^' .. vim.pesc(utils.expand(d))) then
-        skip[p] = true
-      end
+    if f and f ~= '' then
+      skip[utils.expand(f)] = true
     end
   end
-
-  local ok_api, api_root = pcall(require, 'orgmode.api')
-  if not ok_api then
-    return {}
-  end
-  local org_api = api_root.load and api_root or api_root.org
-  if not (org_api and org_api.load) then
-    return {}
+  local skip_dirs = {}
+  for _, d in ipairs(C.exclude_directories or {}) do
+    if d and d ~= '' then
+      skip_dirs[#skip_dirs + 1] = utils.expand(d)
+    end
   end
 
   local files = {}
-  for path in pairs(want) do
-    if not skip[path] then
-      local ok, f = pcall(org_api.load, path)
-      if ok and f then
-        if f.filename or f._file then
-          files[#files + 1] = f
-        elseif vim.islist(f) then
-          vim.list_extend(files, f)
+  for _, f in ipairs(all_files) do
+    local path = f.filename or (f._file and f._file.filename)
+    if path and not skip[path] then
+      local excluded = false
+      for _, d in ipairs(skip_dirs) do
+        if path:find('^' .. vim.pesc(d)) then
+          excluded = true
+          break
         end
+      end
+      if not excluded then
+        files[#files + 1] = f
       end
     end
   end
-  for i, f in ipairs(files) do
-    files[i] = f:reload()
-  end
+
   return files
 end
 

--- a/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
+++ b/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
@@ -10,6 +10,17 @@ local S = {}
 local function load_org_files()
   local C = cfg()
 
+  local ok_org, orgmode = pcall(require, 'orgmode')
+  if not ok_org or not orgmode or not orgmode.files or not orgmode.files.load_sync then
+    error('nvim-orgmode is required but not found. Please install nvim-orgmode/orgmode')
+  end
+
+  -- Ensure orgmode has fully loaded agenda files before reading them.
+  -- Without this, orgmode.api.load() can return an empty/partial list on first open.
+  pcall(function()
+    orgmode.files:load_sync(false, 20000)
+  end)
+
   local ok_api, org_api = pcall(require, 'orgmode.api')
   if not ok_api or not org_api or not org_api.load then
     error('nvim-orgmode is required but not found. Please install nvim-orgmode/orgmode')
@@ -47,7 +58,11 @@ local function load_org_files()
         end
       end
       if not excluded then
-        files[#files + 1] = f
+        if f.reload then
+          files[#files + 1] = f:reload()
+        else
+          files[#files + 1] = f
+        end
       end
     end
   end

--- a/lua/org-super-agenda/adapters/neovim/utils.lua
+++ b/lua/org-super-agenda/adapters/neovim/utils.lua
@@ -6,18 +6,6 @@ function U.expand(path)
   return (path:gsub('^~', vim.fn.expand('$HOME')))
 end
 
-function U.get_org_files(dir)
-  local res, cmd = {}, string.format('find %q -type f -name "*.org"', U.expand(dir))
-  local handle = io.popen(cmd)
-  if handle then
-    for f in handle:lines() do
-      res[#res + 1] = f
-    end
-    handle:close()
-  end
-  return res
-end
-
 function U.show_help()
   local cfg = get_cfg()
   local km = cfg.keymaps or {}

--- a/lua/org-super-agenda/config.lua
+++ b/lua/org-super-agenda/config.lua
@@ -158,6 +158,10 @@ M.defaults = {
   show_other_group = false,
   show_tags = true,
   show_filename = true,
+  -- How bulk action prompts are shown:
+  --   'keys'   = inline key hints + getchar (fast keyboard flow)
+  --   'select' = vim.ui.select picker (better with UI routers like noice.nvim)
+  bulk_action_prompt = 'keys',
   heading_max_length = 70,
   persist_hidden = false,
   fold_item_action = 'preview',

--- a/lua/org-super-agenda/config.lua
+++ b/lua/org-super-agenda/config.lua
@@ -2,8 +2,6 @@
 local M = {}
 
 M.defaults = {
-  org_files = {},
-  org_directories = {},
   exclude_files = {},
   exclude_directories = {},
   keymaps = {

--- a/lua/org-super-agenda/core/layout/classic.lua
+++ b/lua/org-super-agenda/core/layout/classic.lua
@@ -8,11 +8,17 @@ local function truncate(str, len)
   return str:sub(1, len)
 end
 
+local function file_stem(path)
+  local p = (path or ''):gsub('\\', '/')
+  local base = p:match('[^/]+$') or ''
+  return base:gsub('%.org$', '')
+end
+
 local function classic_prefix(it, cfg)
   local indent = '  ' .. string.rep(' ', it.level or 0)
   local pri = (it.priority and it.priority ~= '') and ('[#' .. it.priority .. ']') or nil
   local parts = {
-    filename = (cfg.show_filename and it.file) and (it.file:match('[^/]+$') or ''):gsub('%.org$', ''),
+    filename = (cfg.show_filename and it.file) and file_stem(it.file),
     todo = it.todo_state,
     priority = pri,
     headline = truncate(it.headline or '', cfg.heading_max_length),
@@ -91,7 +97,7 @@ function L.build(groups, win_width, cfg, marked)
           local meta_str = table.concat(meta, ' ')
 
           local parts = {
-            filename = (cfg.show_filename and it.file) and (it.file:match('[^/]+$') or ''):gsub('%.org$', ''),
+            filename = (cfg.show_filename and it.file) and file_stem(it.file),
             todo = it.todo_state,
             priority = pri,
             headline = truncate(it.headline or '', cfg.heading_max_length),

--- a/lua/org-super-agenda/core/layout/compact.lua
+++ b/lua/org-super-agenda/core/layout/compact.lua
@@ -8,6 +8,12 @@ local function truncate(str, len)
   return str:sub(1, len)
 end
 
+local function file_stem(path)
+  local p = (path or ''):gsub('\\', '/')
+  local base = p:match('[^/]+$') or ''
+  return base:gsub('%.org$', '')
+end
+
 local MARK_GLYPH = '● '
 local CLOCK_GLYPH = '⏱ '
 local function item_key(it)
@@ -49,7 +55,7 @@ function L.build(groups, win_width, cfg, marked)
 
   for _, grp in ipairs(groups) do
     for _, it in ipairs(grp.items) do
-      local name = ((it.file or ''):match('[^/]+$') or ''):gsub('%.org$', '') .. ':'
+      local name = file_stem(it.file) .. ':'
       if #name > fname_w then
         fname_w = #name
       end
@@ -72,7 +78,7 @@ function L.build(groups, win_width, cfg, marked)
 
       if not grp.collapsed then
         for _, it in ipairs(grp.items) do
-          local name = (((it.file or ''):match('[^/]+$') or ''):gsub('%.org$', '') .. ':')
+          local name = file_stem(it.file) .. ':'
           local label = build_labels(it)
           if label == '' then
             label = string.rep(' ', label_w)
@@ -92,6 +98,7 @@ function L.build(groups, win_width, cfg, marked)
           local s_fn = #text
           text = text .. string.format('%-' .. fname_w .. 's', name)
           spans[#spans + 1] = { field = 'filename', s = s_fn, e = #text, state = it.todo_state }
+          text = text .. ' '
           local s_lab = #text
           text = text .. label
           spans[#spans + 1] = { field = 'date', s = s_lab, e = #text, state = it.todo_state }

--- a/tests/helpers/min.lua
+++ b/tests/helpers/min.lua
@@ -8,7 +8,12 @@ package.path = table.concat({
 
 -- --- orgmode‑Stubs ----------------------------------------------------
 package.preload['orgmode'] = function()
-  return { reload = function() end }
+  return {
+    reload = function() end,
+    config = {
+      org_agenda_files = {},
+    },
+  }
 end
 package.preload['orgmode.api'] = function()
   local function load(_)
@@ -17,10 +22,7 @@ package.preload['orgmode.api'] = function()
   return { load = load, org = { load = load } }
 end
 
-require('org-super-agenda').setup({
-  org_files = {},
-  org_directories = {},
-})
+require('org-super-agenda').setup({})
 
 if vim.islist == nil then
   vim.islist = vim.tbl_islist


### PR DESCRIPTION
## What does this PR do?
Use nvim-orgmode’s org_agenda_files as the single source of truth for agenda file discovery.
This removes the redundant org_files and org_directories options from org-super-agenda and makes file resolution consistent with orgmode itself. It also improves cross-platform path handling, especially on Windows.
Type
- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Docs / refactor

## Notes
- org-super-agenda now reads agenda files directly from nvim-orgmode
- org_files and org_directories have been removed from this plugin
- users must configure agenda files in require("orgmode").setup({ org_agenda_files = { ... } })
- this simplifies configuration and avoids duplicate path setup
- fixes Windows-specific path issues caused by custom file discovery logic


<!-- A short description of the change and why it's needed -->

<!-- Anything the reviewer should know: edge cases, related issues, testing notes -->

<!-- Fixes #18  -->