### PR TITLE
chore: release v2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g \
-            semantic-release \
-            @semantic-release/git \
-            @semantic-release/changelog \
-            conventional-changelog-conventionalcommits
+            semantic-release@24.2.9 \
+            @semantic-release/git@10.0.1 \
+            @semantic-release/changelog@6.0.3 \
+            conventional-changelog-conventionalcommits@8.0.0
       
       - name: Release
         env:

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,8 +1,4 @@
 // .releaserc.js
-// Commits from external contributors (anyone not 'hamidi-dev') get a
-// "thanks @author" suffix automatically in the release notes.
-const MAINTAINER_NAMES = ['mohamed hamidi', 'hamidi-dev']
-
 module.exports = {
   branches: ['main'],
   plugins: [
@@ -37,22 +33,6 @@ module.exports = {
             { type: 'chore', hidden: true },
             { type: 'test', hidden: true },
           ],
-        },
-        gitRawCommitsOpts: {
-          format: '%B%n-hash-%n%H%n-gitTags-%n%d%n-committerDate-%n%ci%n-authorName-%n%an',
-        },
-        writerOpts: {
-          transform: (commit, context) => {
-            if (!commit.type) return commit
-
-            // authorName is injected via the custom gitRawCommitsOpts format
-            const login = commit.authorName || ''
-            if (login && !MAINTAINER_NAMES.includes(login.toLowerCase())) {
-              commit.subject = `${commit.subject} — thanks @${login}`
-            }
-
-            return commit
-          },
         },
       },
     ],

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ A Neovim plugin inspired by [org-super-agenda](https://github.com/alphapapa/org-
 * **Toggle duplicates** across groups (`D`)
 * **Group folding**: `<Tab>` on headers, fold all (`zM`), unfold all (`zR`)
 * **Custom views** with pre-configured filters, groups, sort, and global keymaps (`V` picker)
-* **Switch view** between `classic` and `compact` (`ov`)
+* **Switch view** between `classic`, `compact`, and `tree` (`ov`)
+* **Tree view**: subtasks nest under their parent task with `├─`/`└─` connectors; parents outside the group appear as dimmed context rows
 * **Right‑aligned tags**, customizable header format, and filename display
 * **Safety**: refuses edits when a swapfile is present or buffer is modified elsewhere
 * **Sticky DONE**: items marked DONE during the session remain visible until you close the window
@@ -110,7 +111,7 @@ return {
         fold_all          = 'zM', -- collapse all groups
         unfold_all        = 'zR', -- expand all groups
         toggle_duplicates = 'D',  -- duplicate items may appear in multiple groups
-        cycle_view        = 'ov', -- switch view (classic/compact)
+        cycle_view        = 'ov', -- switch view (classic/compact/tree)
         bulk_mark         = 'm',  -- toggle mark on current item (● indicator)
         bulk_unmark_all   = 'M',  -- clear all marks
         bulk_reselect     = 'gv', -- reselect last marks
@@ -162,10 +163,11 @@ return {
       bulk_action_prompt = 'keys',    -- 'keys' (fast keypress) | 'select' (vim.ui.select / noice-friendly)
       heading_max_length = 70,
       persist_hidden     = false,     -- keep hidden items across reopen
-      view_mode          = 'classic', -- 'classic' | 'compact'
+      view_mode          = 'classic', -- 'classic' | 'compact' | 'tree'
 
       classic = { heading_order={'filename','todo','priority','headline'}, short_date_labels=false, inline_dates=true },
       compact = { filename_min_width=10, label_min_width=12 },
+      tree    = { show_ghost_parents=true }, -- dimmed context rows for parents outside the group
 
       -- Global fallback sort for groups that omit `sort`
       group_sort = { by='date_nearest', order='asc' },
@@ -388,6 +390,21 @@ When a custom view is active:
 
 * **classic**: headline prefix `[filename] TODO [#A] Title …` with inline or separate date line
 * **compact**: fixed columns for filename and date label (`Sched. in 3 d.:`), right-aligned tags
+* **tree**: hierarchy view — subtasks nest under their parent task within each group:
+
+  ```
+  * 💼 Work (4 items)
+    TODO Release v2.1
+    ├─ PROGRESS Write migration guide
+    │  └─ TODO Review code samples
+    └─ TODO Update screenshots
+  ```
+
+  Items keep the classic formatting; nesting follows the real org outline. When a
+  subtask matches a group but its parent doesn't (e.g. only the subtask is
+  scheduled today), the parent is shown as a **dimmed context row** so you still
+  see where the task belongs — disable with `tree = { show_ghost_parents = false }`.
+  Context rows are navigable: `<CR>`, `gf`, and `K` work on them like on normal items.
 
 Switch with `ov` (or set `view_mode` in config).
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ return {
       show_other_group   = false,     -- show catch-all section
       show_tags          = true,      -- draw tags on the right
       show_filename      = true,      -- include [filename]
+      bulk_action_prompt = 'keys',    -- 'keys' (fast keypress) | 'select' (vim.ui.select / noice-friendly)
       heading_max_length = 70,
       persist_hidden     = false,     -- keep hidden items across reopen
       view_mode          = 'classic', -- 'classic' | 'compact'

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A Neovim plugin inspired by [org-super-agenda](https://github.com/alphapapa/org-
 * **Right‑aligned tags**, customizable header format, and filename display
 * **Safety**: refuses edits when a swapfile is present or buffer is modified elsewhere
 * **Sticky DONE**: items marked DONE during the session remain visible until you close the window
+* **Repeat tasks**: repeating TODOs follow nvim-orgmode behavior when marked done (advance repeater dates, reset state, preserve repeat metadata)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,15 @@ return {
     { 'lukas-reineke/headlines.nvim', config = true }, -- optional nicety
   },
   config = function()
+    -- First configure nvim-orgmode with your agenda files
+    require('orgmode').setup({
+      org_agenda_files = {'~/org/**/*', '~/work/**/*.org'},
+      -- ... other orgmode config
+    })
+
+    -- org-super-agenda will automatically use orgmode's org_agenda_files
     require('org-super-agenda').setup({
-      -- Where to look for .org files
-      org_files           = {},
-      org_directories     = {}, -- recurse for *.org
+      -- Optional: exclude specific files or directories from the agenda
       exclude_files       = {},
       exclude_directories = {},
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,12 @@ return {
       -- ... other orgmode config
     })
 
-    -- org-super-agenda will automatically use orgmode's org_agenda_files
+    -- org-super-agenda automatically uses orgmode's org_agenda_files.
+    -- Existing org_files/org_directories overrides remain supported; when
+    -- either is non-empty, they replace org_agenda_files and combine together.
     require('org-super-agenda').setup({
+      org_files           = {}, -- optional explicit file overrides
+      org_directories     = {}, -- optional recursive directory overrides
       -- Optional: exclude specific files or directories from the agenda
       exclude_files       = {},
       exclude_directories = {},

--- a/doc/org-super-agenda.txt
+++ b/doc/org-super-agenda.txt
@@ -519,6 +519,7 @@ M.defaults = {
   show_other_group    = false,
   show_tags           = true,
   show_filename       = true,
+  bulk_action_prompt  = 'keys', -- 'keys' | 'select'
   heading_max_length  = 70,
   persist_hidden      = false,
   fold_item_action    = 'preview',  -- 'preview' or 'goto'

--- a/doc/org-super-agenda.txt
+++ b/doc/org-super-agenda.txt
@@ -571,6 +571,8 @@ SAFETY NOTES                                                  *org-super-agenda-
 * Refuses edits if buffer is modified in Neovim or a swapfile is detected
 * DONE items set during the session remain visible in a dedicated group
   until the agenda window is closed ("sticky DONE")
+* Repeating TODOs follow nvim-orgmode behavior when marked done:
+  repeater dates advance, todo state resets, and repeat metadata is preserved
 * The catch‑all "Other" group never collects DONE items
 
 ===============================================================================

--- a/doc/org-super-agenda.txt
+++ b/doc/org-super-agenda.txt
@@ -67,9 +67,13 @@ require('orgmode').setup({
 })
 ```
 
-org-super-agenda will automatically use orgmode's org_agenda_files:
+org-super-agenda automatically uses orgmode's org_agenda_files. Existing
+org_files/org_directories overrides remain supported. If either override is
+non-empty, both are combined and used instead of org_agenda_files:
 ```
 require('org-super-agenda').setup({
+  org_files           = {},        -- optional explicit file overrides
+  org_directories     = {},        -- optional recursive directory overrides
   exclude_files       = {},        -- optional: files to ignore
   exclude_directories = {},        -- optional: directories to ignore
   -- additional options are documented below and in the source
@@ -405,6 +409,8 @@ The defaults (see |lua/org-super-agenda/config.lua|) are:
 
 >
 M.defaults = {
+  org_files           = {}, -- optional; overrides org_agenda_files when set
+  org_directories     = {}, -- optional; overrides org_agenda_files when set
   exclude_files       = {},
   exclude_directories = {},
   keymaps             = {

--- a/doc/org-super-agenda.txt
+++ b/doc/org-super-agenda.txt
@@ -42,7 +42,7 @@ to toggle collapse/expand; on an item line it runs `fold_item_action`
         gI        Jump to active clock task
         D         Toggle allowing duplicates across groups
         zM / zR   Fold all / unfold all groups
-        ov        Switch view mode (classic ↔ compact)
+        ov        Switch view mode (classic → compact → tree)
         V         Open custom view picker
         x / gX    Hide current item / reset hidden list
         R         Refile via Telescope (see |org-super-agenda-refile|)
@@ -372,7 +372,7 @@ filter          Query string (same syntax as |org-super-agenda-query|)
 groups          Override default group structure for this view
 sort            View-level sort fallback (between per-group and global)
 title           Custom window title override
-view_mode       Layout override ('classic' or 'compact')
+view_mode       Layout override ('classic', 'compact' or 'tree')
 
 All fields are optional. A view with just a `filter` is valid.
 
@@ -523,9 +523,10 @@ M.defaults = {
   heading_max_length  = 70,
   persist_hidden      = false,
   fold_item_action    = 'preview',  -- 'preview' or 'goto'
-  view_mode           = 'classic',
+  view_mode           = 'classic', -- 'classic' | 'compact' | 'tree'
   classic             = { heading_order = { 'filename', 'todo', 'priority', 'headline' }, short_date_labels = false, inline_dates = true },
   compact             = { filename_min_width = 10, label_min_width = 12 },
+  tree                = { show_ghost_parents = true },
 
   -- Global fallback sort for groups that don't specify their own `sort`
   group_sort          = { by = 'date_nearest', order = 'asc' },

--- a/doc/org-super-agenda.txt
+++ b/doc/org-super-agenda.txt
@@ -59,11 +59,19 @@ Call |lua| to setup the plugin:
 lua << EOF
 ```
 
+First configure nvim-orgmode with your agenda files:
+```
+require('orgmode').setup({
+  org_agenda_files = {'~/org/**/*', '~/work/**/*.org'},
+  -- ... other orgmode config
+})
+```
+
+org-super-agenda will automatically use orgmode's org_agenda_files:
 ```
 require('org-super-agenda').setup({
-  org_directories     = {},        -- recurse for *.org files
-  exclude_files       = {},        -- files to ignore
-  exclude_directories = {},        -- directories to ignore
+  exclude_files       = {},        -- optional: files to ignore
+  exclude_directories = {},        -- optional: directories to ignore
   -- additional options are documented below and in the source
 })
 EOF
@@ -397,8 +405,6 @@ The defaults (see |lua/org-super-agenda/config.lua|) are:
 
 >
 M.defaults = {
-  org_files           = {},
-  org_directories     = {},
   exclude_files       = {},
   exclude_directories = {},
   keymaps             = {

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -96,22 +96,68 @@ local function clock_goto_active()
 end
 
 -- === helpers: swap detection, buffer status, snapshots, safe writes ===
-local function has_swap_for(path)
-  -- Heuristic: look for .*{basename}*.sw?
-  local dir = vim.fn.fnamemodify(path, ':p:h')
-  local base = vim.fn.fnamemodify(path, ':t')
-  local patt = dir .. '/.*' .. vim.fn.escape(base, '[]^$\\.*') .. '.*.sw?'
-  return vim.fn.glob(patt) ~= ''
-end
-
 local function is_swap_error(err)
   local s = tostring(err or '')
   return s:find('Vim:E325', 1, true) ~= nil or s:find('E325:', 1, true) ~= nil
 end
 
+local function swap_glob_candidates(path)
+  local abs = vim.fn.fnamemodify(path, ':p')
+  local base = vim.fn.fnamemodify(abs, ':t')
+  local candidates = {}
+
+  local dir_entries = vim.opt.directory:get()
+  if type(dir_entries) ~= 'table' then
+    dir_entries = vim.split(vim.o.directory or '', ',', { plain = true, trimempty = true })
+  end
+
+  for _, entry in ipairs(dir_entries or {}) do
+    if entry and entry ~= '' and entry ~= '.' then
+      local expanded = vim.fn.expand(entry)
+      if expanded:sub(-2) == '//' then
+        local root = expanded:gsub('/+$', '')
+        local mangled = abs:gsub('[:/\\]', '%%')
+        candidates[#candidates + 1] = root .. '/' .. mangled .. '.sw?'
+      else
+        local root = expanded:gsub('/+$', '')
+        candidates[#candidates + 1] = root .. '/.' .. vim.fn.escape(base, '[]^$\\.*') .. '.*.sw?'
+      end
+    end
+  end
+
+  local local_dir = vim.fn.fnamemodify(abs, ':h')
+  candidates[#candidates + 1] = local_dir .. '/.' .. vim.fn.escape(base, '[]^$\\.*') .. '.*.sw?'
+  return candidates
+end
+
+local function has_swap_for(path)
+  for _, patt in ipairs(swap_glob_candidates(path)) do
+    if patt and patt ~= '' and vim.fn.glob(patt) ~= '' then
+      return true
+    end
+  end
+  return false
+end
+
 local function notify_swap_conflict(path, action)
   local short = vim.fn.fnamemodify(path or '', ':~:.')
-  vim.notify(string.format('%s blocked: swap-file conflict (E325) for %s. Resolve the swap/recovery prompt and try again.', action, short), vim.log.levels.WARN)
+  local msg = string.format('%s blocked: swap-file conflict (E325) for %s. Resolve the swap/recovery prompt and try again.', action, short)
+  vim.notify(msg, vim.log.levels.WARN, { title = 'org-super-agenda' })
+  pcall(vim.api.nvim_echo, { { msg, 'WarningMsg' } }, true, {})
+end
+
+local function notify_action_error(action, err, path)
+  if type(err) == 'table' and err.kind == 'swap_conflict' then
+    notify_swap_conflict(err.path or path, action)
+    return
+  end
+
+  if type(err) == 'string' and err:find('Detected a swap file', 1, true) then
+    notify_swap_conflict(path, action)
+    return
+  end
+
+  vim.notify(tostring(err), vim.log.levels.WARN, { title = 'org-super-agenda' })
 end
 
 local function buf_status_for(path)
@@ -377,12 +423,21 @@ end
 
 local function apply_heading_state_via_orgmode(hl, next_state)
   local todos = get_headline_todo_keywords(hl)
+  local path = (hl.file and hl.file.filename) or hl.filename
   local current_value = hl.todo_value or (hl._section and hl._section:get_todo()) or ''
   local current_kw = current_value ~= '' and todos and todos:find(current_value) or nil
   local target_kw = todos and todos:find(next_state) or nil
 
   if not todos or not current_kw or not target_kw then
     return false, 'Could not resolve orgmode todo state transition'
+  end
+
+  local st = buf_status_for(path)
+  if st.loaded and st.modified then
+    return false, 'File is open and modified in this Neovim; aborting to avoid data loss.'
+  end
+  if (not st.loaded) and has_swap_for(path) then
+    return false, { kind = 'swap_conflict', path = path }
   end
 
   local ok, result = pcall(function()
@@ -608,7 +663,7 @@ local function set_state_for_headline(line_map, next_state)
 
     local success, updated = apply_heading_state(hl, next_state)
     if not success then
-      vim.notify(updated, vim.log.levels.WARN)
+      notify_action_error('Set state', updated, hl.file and hl.file.filename)
       return
     end
 
@@ -864,7 +919,7 @@ local function bulk_action_menu(line_map)
           restores[#restores + 1] = make_restore_from_snapshot(snap)
           local ok3, updated = apply_heading_state(hl, next_state)
           if not ok3 then
-            vim.notify(updated, vim.log.levels.WARN)
+            notify_action_error('Bulk state change', updated, hl.file and hl.file.filename)
           else
             local key = key_for_hl(updated or hl)
             if updated and updated.todo_type == 'DONE' then
@@ -1467,7 +1522,7 @@ function A.set_keymaps(buf, win, line_map, reopen)
 
       local ok, updated = apply_heading_state(hl, next_state)
       if not ok then
-        vim.notify(updated, vim.log.levels.WARN)
+        notify_action_error('Cycle TODO', updated, hl.file and hl.file.filename)
         return
       end
 

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -1142,7 +1142,7 @@ function A.set_keymaps(buf, win, line_map, reopen)
       -- Popup mode: detach from tmux session to hide the popup
       vim.fn.system(popup.hide_command)
     else
-      -- Normal mode: close window + buffer
+      -- Normal mode: close buffer and window
       if vim.api.nvim_win_is_valid(win) then
         pcall(vim.api.nvim_win_close, win, true)
       end

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -104,6 +104,16 @@ local function has_swap_for(path)
   return vim.fn.glob(patt) ~= ''
 end
 
+local function is_swap_error(err)
+  local s = tostring(err or '')
+  return s:find('Vim:E325', 1, true) ~= nil or s:find('E325:', 1, true) ~= nil
+end
+
+local function notify_swap_conflict(path, action)
+  local short = vim.fn.fnamemodify(path or '', ':~:.')
+  vim.notify(string.format('%s blocked: swap-file conflict (E325) for %s. Resolve the swap/recovery prompt and try again.', action, short), vim.log.levels.WARN)
+end
+
 local function buf_status_for(path)
   local bufnr = vim.fn.bufnr(path)
   if bufnr == -1 then
@@ -561,12 +571,22 @@ local function bulk_apply_date(targets, cur, first_hl, snap_first, keyword, open
     return
   end
 
+  local st0 = buf_status_for(fname)
+  if (not st0.loaded) and has_swap_for(fname) then
+    notify_swap_conflict(fname, keyword)
+    return
+  end
+
   -- read planning stamp BEFORE the picker runs (to detect removal afterwards)
   local before_stamp = find_stamp_near(fname, start_l, keyword)
 
   local ok_p, p = pcall(open_picker, first_hl)
   if not ok_p then
-    vim.notify('Could not open datepicker: ' .. tostring(p), vim.log.levels.WARN)
+    if is_swap_error(p) then
+      notify_swap_conflict(fname, keyword)
+    else
+      vim.notify('Could not open datepicker: ' .. tostring(p), vim.log.levels.WARN)
+    end
     return
   end
 
@@ -942,9 +962,24 @@ function A.set_keymaps(buf, win, line_map, reopen)
   -- reschedule / deadline (unchanged but undo-aware)
   vim.keymap.set('n', cfg.keymaps.reschedule, function()
     with_headline(line_map, function(cur, hl)
-      local st = buf_status_for(hl.file.filename)
-      local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl.file.filename, hl.position.start_line)
-      local p = hl:set_scheduled()
+      local path = hl.file.filename
+      local st = buf_status_for(path)
+      if (not st.loaded) and has_swap_for(path) then
+        notify_swap_conflict(path, 'Reschedule')
+        return
+      end
+      local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(path, hl.position.start_line)
+      local ok_p, p = pcall(function()
+        return hl:set_scheduled()
+      end)
+      if not ok_p then
+        if is_swap_error(p) then
+          notify_swap_conflict(path, 'Reschedule')
+        else
+          vim.notify('Could not open datepicker: ' .. tostring(p), vim.log.levels.WARN)
+        end
+        return
+      end
       local function after()
         Store.push_undo(make_restore_from_snapshot(snap))
         Services.agenda.refresh(cur)
@@ -959,9 +994,24 @@ function A.set_keymaps(buf, win, line_map, reopen)
 
   vim.keymap.set('n', cfg.keymaps.set_deadline, function()
     with_headline(line_map, function(cur, hl)
-      local st = buf_status_for(hl.file.filename)
-      local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl.file.filename, hl.position.start_line)
-      local p = hl:set_deadline()
+      local path = hl.file.filename
+      local st = buf_status_for(path)
+      if (not st.loaded) and has_swap_for(path) then
+        notify_swap_conflict(path, 'Set deadline')
+        return
+      end
+      local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(path, hl.position.start_line)
+      local ok_p, p = pcall(function()
+        return hl:set_deadline()
+      end)
+      if not ok_p then
+        if is_swap_error(p) then
+          notify_swap_conflict(path, 'Set deadline')
+        else
+          vim.notify('Could not open datepicker: ' .. tostring(p), vim.log.levels.WARN)
+        end
+        return
+      end
       local function after()
         Store.push_undo(make_restore_from_snapshot(snap))
         Services.agenda.refresh(cur)

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -799,7 +799,10 @@ function A.set_keymaps(buf, win, line_map, reopen)
       -- Popup mode: detach from tmux session to hide the popup
       vim.fn.system(popup.hide_command)
     else
-      -- Normal mode: close buffer
+      -- Normal mode: close window + buffer
+      if vim.api.nvim_win_is_valid(win) then
+        pcall(vim.api.nvim_win_close, win, true)
+      end
       if vim.api.nvim_buf_is_valid(buf) then
         pcall(vim.api.nvim_buf_delete, buf, { force = true })
       end

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -424,6 +424,7 @@ end
 local function apply_heading_state_via_orgmode(hl, next_state)
   local todos = get_headline_todo_keywords(hl)
   local path = (hl.file and hl.file.filename) or hl.filename
+  local start_line = hl.position and hl.position.start_line or 1
   local current_value = hl.todo_value or (hl._section and hl._section:get_todo()) or ''
   local current_kw = current_value ~= '' and todos and todos:find(current_value) or nil
   local target_kw = todos and todos:find(next_state) or nil
@@ -440,77 +441,95 @@ local function apply_heading_state_via_orgmode(hl, next_state)
     return false, { kind = 'swap_conflict', path = path }
   end
 
-  local ok, result = pcall(function()
-    return hl:_do_action(function()
-      local org = require('orgmode')
-      local instance = org.instance()
-      local mappings = instance and instance.org_mappings
-      local current = instance and instance.files and instance.files:get_closest_headline()
-      if not current then
-        error('orgmode todo transition engine is unavailable', 0)
-      end
+  local function run_transition()
+    local org = require('orgmode')
+    local instance = org.instance()
+    local mappings = instance and instance.org_mappings
+    local current = instance and instance.files and instance.files:get_closest_headline()
+    if not current then
+      error('orgmode todo transition engine is unavailable', 0)
+    end
 
-      local old_state = current:get_todo()
-      local was_done = current:is_done()
-      current:set_todo(next_state)
+    local old_state = current:get_todo()
+    local was_done = current:is_done()
+    current:set_todo(next_state)
 
-      local item = instance.files:get_closest_headline()
-      local is_done = item:is_done() and not was_done
-      local is_undone = not item:is_done() and was_done
+    local item = instance.files:get_closest_headline()
+    local is_done = item:is_done() and not was_done
+    local is_undone = not item:is_done() and was_done
 
-      if not is_done and not is_undone then
-        return true
-      end
-
-      local org_config = require('orgmode.config')
-      local Date = require('orgmode.objects.date')
-      local TodoState = require('orgmode.objects.todo_state')
-      local repeater_dates = item:get_repeater_dates()
-
-      if #repeater_dates == 0 then
-        local log_closed_time = org_config.org_log_done == 'time'
-        if log_closed_time then
-          if is_done then
-            item:set_closed_date()
-          elseif is_undone then
-            item:remove_closed_date()
-          end
-        end
-        return true
-      end
-
-      if not (mappings and mappings._replace_date) then
-        error('orgmode repeater engine is unavailable', 0)
-      end
-
-      for _, date in ipairs(repeater_dates) do
-        mappings:_replace_date(date:apply_repeater())
-      end
-
-      item = instance.files:get_closest_headline()
-      local new_todo = item:get_todo()
-      local todo_state = TodoState:new({ current_state = new_todo, todos = item.file:get_todo_keywords() })
-      local reset_keyword = todo_state:get_reset_todo(item, old_state)
-      item:set_todo(reset_keyword.value)
-
-      local log_repeat_enabled = org_config.org_log_repeat ~= false
-      local prompt_repeat_note = org_config.org_log_repeat == 'note'
-      local prompt_done_note = org_config.org_log_done == 'note'
-      if log_repeat_enabled then
-        item:set_property('LAST_REPEAT', Date.now():to_wrapped_string(false))
-        if not prompt_repeat_note and not prompt_done_note then
-          local indent = item:get_indent()
-          local repeat_note_template = ('%s- State %-12s from %-12s [%s]'):format(
-            indent,
-            [["]] .. (new_todo or '') .. [["]],
-            [["]] .. (old_state or '') .. [["]],
-            Date.now():to_string()
-          )
-          item:add_note({ repeat_note_template })
-        end
-      end
-
+    if not is_done and not is_undone then
       return true
+    end
+
+    local org_config = require('orgmode.config')
+    local Date = require('orgmode.objects.date')
+    local TodoState = require('orgmode.objects.todo_state')
+    local repeater_dates = item:get_repeater_dates()
+
+    if #repeater_dates == 0 then
+      local log_closed_time = org_config.org_log_done == 'time'
+      if log_closed_time then
+        if is_done then
+          item:set_closed_date()
+        elseif is_undone then
+          item:remove_closed_date()
+        end
+      end
+      return true
+    end
+
+    if not (mappings and mappings._replace_date) then
+      error('orgmode repeater engine is unavailable', 0)
+    end
+
+    for _, date in ipairs(repeater_dates) do
+      mappings:_replace_date(date:apply_repeater())
+    end
+
+    item = instance.files:get_closest_headline()
+    local new_todo = item:get_todo()
+    local todo_state = TodoState:new({ current_state = new_todo, todos = item.file:get_todo_keywords() })
+    local reset_keyword = todo_state:get_reset_todo(item, old_state)
+    item:set_todo(reset_keyword.value)
+
+    local log_repeat_enabled = org_config.org_log_repeat ~= false
+    local prompt_repeat_note = org_config.org_log_repeat == 'note'
+    local prompt_done_note = org_config.org_log_done == 'note'
+    if log_repeat_enabled then
+      item:set_property('LAST_REPEAT', Date.now():to_wrapped_string(false))
+      if not prompt_repeat_note and not prompt_done_note then
+        local indent = item:get_indent()
+        local repeat_note_template = ('%s- State %-12s from %-12s [%s]'):format(
+          indent,
+          [["]] .. (new_todo or '') .. [["]],
+          [["]] .. (old_state or '') .. [["]],
+          Date.now():to_string()
+        )
+        item:add_note({ repeat_note_template })
+      end
+    end
+
+    return true
+  end
+
+  local ok, result = pcall(function()
+    if st.loaded then
+      return vim.api.nvim_buf_call(st.bufnr, function()
+        local view = vim.fn.winsaveview() or {}
+        vim.fn.cursor({ start_line, 1 })
+        run_transition()
+        vim.cmd('silent noautocmd write')
+        vim.fn.winrestview(view)
+        local ok_reload, reloaded = pcall(function()
+          return hl:reload()
+        end)
+        return ok_reload and reloaded or hl
+      end)
+    end
+
+    return hl:_do_action(function()
+      return run_transition()
     end):wait(20000)
   end)
 
@@ -751,6 +770,55 @@ local function find_stamp_near(path, start_line, keyword)
     end
   end
   return nil
+end
+
+local function open_loaded_datepicker(hl, keyword, bufnr)
+  local Calendar = require('orgmode.objects.calendar')
+  local Date = require('orgmode.objects.date')
+
+  local get_date = keyword == 'SCHEDULED' and 'get_scheduled_date' or 'get_deadline_date'
+  local set_date = keyword == 'SCHEDULED' and 'set_scheduled_date' or 'set_deadline_date'
+  local remove_date = keyword == 'SCHEDULED' and 'remove_scheduled_date' or 'remove_deadline_date'
+  local title = keyword == 'SCHEDULED' and 'Set schedule' or 'Set deadline'
+  local initial = hl._section and hl._section[get_date] and hl._section[get_date](hl._section) or Date.today()
+
+  return Calendar.new({ date = initial, clearable = true, title = title }):open():next(function(new_date, cleared)
+    if not new_date and not cleared then
+      return
+    end
+
+    return vim.api.nvim_buf_call(bufnr, function()
+      local view = vim.fn.winsaveview() or {}
+      vim.fn.cursor({ hl.position.start_line, 1 })
+
+      local org = require('orgmode')
+      local item = org.instance().files:get_closest_headline()
+      if not item then
+        error('orgmode date change target is unavailable', 0)
+      end
+
+      if cleared then
+        item[remove_date](item)
+      else
+        item[set_date](item, new_date)
+      end
+
+      vim.cmd('silent noautocmd write')
+      vim.fn.winrestview(view)
+      return true
+    end)
+  end)
+end
+
+local function open_headline_datepicker(hl, keyword)
+  local st = buf_status_for(hl.file.filename)
+  if st.loaded then
+    return open_loaded_datepicker(hl, keyword, st.bufnr)
+  end
+  if keyword == 'SCHEDULED' then
+    return hl:set_scheduled()
+  end
+  return hl:set_deadline()
 end
 
 -- Apply a date bulk-op: open datepicker on first_hl, then mirror result to all targets.
@@ -1017,12 +1085,12 @@ local function bulk_action_menu(line_map)
       elseif choice.key == 'r' then
         -- bulk reschedule: prompt once via first item, apply result to all
         bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
-          return hl:set_scheduled()
+          return open_headline_datepicker(hl, 'SCHEDULED')
         end)
       elseif choice.key == 'd' then
         -- bulk deadline: same pattern
         bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
-          return hl:set_deadline()
+          return open_headline_datepicker(hl, 'DEADLINE')
         end)
       end
     end)
@@ -1049,12 +1117,12 @@ local function bulk_action_menu(line_map)
     elseif c == 'r' then
       -- bulk reschedule: prompt once via first item, apply result to all
       bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
-        return hl:set_scheduled()
+        return open_headline_datepicker(hl, 'SCHEDULED')
       end)
     elseif c == 'd' then
       -- bulk deadline: same pattern
       bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
-        return hl:set_deadline()
+        return open_headline_datepicker(hl, 'DEADLINE')
       end)
     end
   end
@@ -1167,7 +1235,7 @@ function A.set_keymaps(buf, win, line_map, reopen)
       end
       local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(path, hl.position.start_line)
       local ok_p, p = pcall(function()
-        return hl:set_scheduled()
+        return open_headline_datepicker(hl, 'SCHEDULED')
       end)
       if not ok_p then
         if is_swap_error(p) then
@@ -1199,7 +1267,7 @@ function A.set_keymaps(buf, win, line_map, reopen)
       end
       local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(path, hl.position.start_line)
       local ok_p, p = pcall(function()
-        return hl:set_deadline()
+        return open_headline_datepicker(hl, 'DEADLINE')
       end)
       if not ok_p then
         if is_swap_error(p) then

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -345,6 +345,147 @@ local function safe_set_heading_state(hl, next_state)
   end
 end
 
+local function get_headline_todo_keywords(hl)
+  local section = hl and hl._section
+  local file = section and section.file
+  if not (file and file.get_todo_keywords) then
+    return nil
+  end
+  return file:get_todo_keywords()
+end
+
+local function should_use_orgmode_state_transition(hl, next_state)
+  if not hl or next_state == '' then
+    return false
+  end
+
+  local todos = get_headline_todo_keywords(hl)
+  if not todos then
+    return false
+  end
+
+  local current_value = hl.todo_value or (hl._section and hl._section:get_todo()) or ''
+  local current_kw = current_value ~= '' and todos:find(current_value) or nil
+  local target_kw = todos:find(next_state)
+
+  if not current_kw or not target_kw then
+    return false
+  end
+
+  return current_kw.sequence_index == target_kw.sequence_index and current_kw.type ~= target_kw.type
+end
+
+local function apply_heading_state_via_orgmode(hl, next_state)
+  local todos = get_headline_todo_keywords(hl)
+  local current_value = hl.todo_value or (hl._section and hl._section:get_todo()) or ''
+  local current_kw = current_value ~= '' and todos and todos:find(current_value) or nil
+  local target_kw = todos and todos:find(next_state) or nil
+
+  if not todos or not current_kw or not target_kw then
+    return false, 'Could not resolve orgmode todo state transition'
+  end
+
+  local ok, result = pcall(function()
+    return hl:_do_action(function()
+      local org = require('orgmode')
+      local instance = org.instance()
+      local mappings = instance and instance.org_mappings
+      local current = instance and instance.files and instance.files:get_closest_headline()
+      if not current then
+        error('orgmode todo transition engine is unavailable', 0)
+      end
+
+      local old_state = current:get_todo()
+      local was_done = current:is_done()
+      current:set_todo(next_state)
+
+      local item = instance.files:get_closest_headline()
+      local is_done = item:is_done() and not was_done
+      local is_undone = not item:is_done() and was_done
+
+      if not is_done and not is_undone then
+        return true
+      end
+
+      local org_config = require('orgmode.config')
+      local Date = require('orgmode.objects.date')
+      local TodoState = require('orgmode.objects.todo_state')
+      local repeater_dates = item:get_repeater_dates()
+
+      if #repeater_dates == 0 then
+        local log_closed_time = org_config.org_log_done == 'time'
+        if log_closed_time then
+          if is_done then
+            item:set_closed_date()
+          elseif is_undone then
+            item:remove_closed_date()
+          end
+        end
+        return true
+      end
+
+      if not (mappings and mappings._replace_date) then
+        error('orgmode repeater engine is unavailable', 0)
+      end
+
+      for _, date in ipairs(repeater_dates) do
+        mappings:_replace_date(date:apply_repeater())
+      end
+
+      item = instance.files:get_closest_headline()
+      local new_todo = item:get_todo()
+      local todo_state = TodoState:new({ current_state = new_todo, todos = item.file:get_todo_keywords() })
+      local reset_keyword = todo_state:get_reset_todo(item, old_state)
+      item:set_todo(reset_keyword.value)
+
+      local log_repeat_enabled = org_config.org_log_repeat ~= false
+      local prompt_repeat_note = org_config.org_log_repeat == 'note'
+      local prompt_done_note = org_config.org_log_done == 'note'
+      if log_repeat_enabled then
+        item:set_property('LAST_REPEAT', Date.now():to_wrapped_string(false))
+        if not prompt_repeat_note and not prompt_done_note then
+          local indent = item:get_indent()
+          local repeat_note_template = ('%s- State %-12s from %-12s [%s]'):format(
+            indent,
+            [["]] .. (new_todo or '') .. [["]],
+            [["]] .. (old_state or '') .. [["]],
+            Date.now():to_string()
+          )
+          item:add_note({ repeat_note_template })
+        end
+      end
+
+      return true
+    end):wait(20000)
+  end)
+
+  if not ok then
+    return false, tostring(result)
+  end
+
+  return true, result
+end
+
+local function apply_heading_state(hl, next_state)
+  if should_use_orgmode_state_transition(hl, next_state) then
+    return apply_heading_state_via_orgmode(hl, next_state)
+  end
+
+  local ok, err = safe_set_heading_state(hl, next_state)
+  if not ok then
+    return false, err
+  end
+
+  local reload_ok, reloaded = pcall(function()
+    return hl:reload()
+  end)
+  if reload_ok and reloaded then
+    return true, reloaded
+  end
+
+  return true, hl
+end
+
 -- === headline toolbelt ===
 local function with_headline(line_map, cb)
   local cur = vim.api.nvim_win_get_cursor(0)
@@ -465,14 +606,14 @@ local function set_state_for_headline(line_map, next_state)
     local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl.file.filename, hl.position.start_line)
     Store.push_undo(make_restore_from_snapshot(snap))
 
-    local success, err = safe_set_heading_state(hl, next_state)
+    local success, updated = apply_heading_state(hl, next_state)
     if not success then
-      vim.notify(err, vim.log.levels.WARN)
+      vim.notify(updated, vim.log.levels.WARN)
       return
     end
 
-    local key = key_for_hl(hl)
-    if next_state == 'DONE' then
+    local key = key_for_hl(updated)
+    if updated.todo_type == 'DONE' then
       Store.sticky_add(key)
     else
       Store.sticky_remove(key)
@@ -721,15 +862,16 @@ local function bulk_action_menu(line_map)
           local st = buf_status_for(hl_fname)
           local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl_fname, hl_start_line(hl))
           restores[#restores + 1] = make_restore_from_snapshot(snap)
-          local ok3, err = safe_set_heading_state(hl, next_state)
+          local ok3, updated = apply_heading_state(hl, next_state)
           if not ok3 then
-            vim.notify(err, vim.log.levels.WARN)
-          end
-          local key = key_for_hl(hl)
-          if next_state == 'DONE' then
-            Store.sticky_add(key)
+            vim.notify(updated, vim.log.levels.WARN)
           else
-            Store.sticky_remove(key)
+            local key = key_for_hl(updated or hl)
+            if updated and updated.todo_type == 'DONE' then
+              Store.sticky_add(key)
+            else
+              Store.sticky_remove(key)
+            end
           end
         end
       end
@@ -1323,14 +1465,14 @@ function A.set_keymaps(buf, win, line_map, reopen)
       local snap = st.loaded and snapshot_heading_from_buf(hl) or snapshot_heading_from_disk(hl.file.filename, hl.position.start_line)
       Store.push_undo(make_restore_from_snapshot(snap))
 
-      local ok, err = safe_set_heading_state(hl, next_state)
+      local ok, updated = apply_heading_state(hl, next_state)
       if not ok then
-        vim.notify(err, vim.log.levels.WARN)
+        vim.notify(updated, vim.log.levels.WARN)
         return
       end
 
-      local key = key_for_hl(hl)
-      if next_state == 'DONE' then
+      local key = key_for_hl(updated)
+      if updated.todo_type == 'DONE' then
         Store.sticky_add(key)
       else
         Store.sticky_remove(key)

--- a/lua/org-super-agenda/adapters/neovim/actions.lua
+++ b/lua/org-super-agenda/adapters/neovim/actions.lua
@@ -682,62 +682,7 @@ local function bulk_action_menu(line_map)
     end
   end
 
-  local count = #targets
-  local chunks = {
-    { 'Bulk (' .. count .. '): ', 'Normal' },
-    { 's', 'Comment' },
-    { '=state  ', 'Normal' },
-    { 'r', 'Comment' },
-    { '=reschedule  ', 'Normal' },
-    { 'd', 'Comment' },
-    { '=deadline', 'Normal' },
-  }
-  vim.api.nvim_echo(chunks, false, {})
-  local ok, c = pcall(vim.fn.getcharstr)
-  vim.api.nvim_echo({}, false, {})
-  if not ok then
-    return
-  end
-
-  local cur = vim.api.nvim_win_get_cursor(0)
-
-  if c == 's' then
-    -- bulk TODO state
-    local seq = {}
-    for _, s in ipairs(get_cfg().todo_states or {}) do
-      seq[#seq + 1] = s.name
-    end
-    if #seq == 0 then
-      return
-    end
-    local shortcuts, _ = build_state_shortcuts(get_cfg().todo_states or {})
-    local sch = { { '0', 'Comment' }, { '=clear  ', 'Normal' } }
-    for _, s in ipairs(shortcuts) do
-      sch[#sch + 1] = { s.key, 'Comment' }
-      sch[#sch + 1] = { '=' .. s.name .. '  ', 'Normal' }
-    end
-    vim.api.nvim_echo(sch, false, {})
-    local ok2, c2 = pcall(vim.fn.getcharstr)
-    vim.api.nvim_echo({}, false, {})
-    if not ok2 then
-      return
-    end
-
-    local next_state
-    if c2 == '0' then
-      next_state = ''
-    else
-      for _, s in ipairs(shortcuts) do
-        if s.key == c2 then
-          next_state = s.name
-          break
-        end
-      end
-    end
-    if next_state == nil then
-      return
-    end
-
+  local function apply_bulk_state(next_state, cur)
     local restores = {}
     for _, it in ipairs(targets) do
       local hl_ok, api_root = pcall(require, 'orgmode.api')
@@ -772,16 +717,129 @@ local function bulk_action_menu(line_map)
     push_bulk_undo(restores)
     Store.mark_clear()
     Services.agenda.refresh(cur)
-  elseif c == 'r' then
-    -- bulk reschedule: prompt once via first item, apply result to all
-    bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
-      return hl:set_scheduled()
+  end
+
+  local function choose_bulk_state_select(cur)
+    local shortcuts, _ = build_state_shortcuts(get_cfg().todo_states or {})
+    if #shortcuts == 0 then
+      return
+    end
+    local options = { { key = '0', name = 'clear' } }
+    for _, s in ipairs(shortcuts) do
+      options[#options + 1] = { key = s.key, name = s.name }
+    end
+    vim.ui.select(options, {
+      prompt = 'Bulk state:',
+      format_item = function(item)
+        return string.format('%s = %s', item.key, item.name)
+      end,
+    }, function(choice)
+      if not choice then
+        return
+      end
+      local next_state = (choice.key == '0') and '' or choice.name
+      apply_bulk_state(next_state, cur)
     end)
-  elseif c == 'd' then
-    -- bulk deadline: same pattern
-    bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
-      return hl:set_deadline()
+  end
+
+  local function choose_bulk_state_keys(cur)
+    local shortcuts, _ = build_state_shortcuts(get_cfg().todo_states or {})
+    if #shortcuts == 0 then
+      return
+    end
+    local sch = { { '0', 'Comment' }, { '=clear  ', 'Normal' } }
+    for _, s in ipairs(shortcuts) do
+      sch[#sch + 1] = { s.key, 'Comment' }
+      sch[#sch + 1] = { '=' .. s.name .. '  ', 'Normal' }
+    end
+    vim.api.nvim_echo(sch, false, {})
+    local ok2, c2 = pcall(vim.fn.getcharstr)
+    vim.api.nvim_echo({}, false, {})
+    if not ok2 then
+      return
+    end
+
+    local next_state
+    if c2 == '0' then
+      next_state = ''
+    else
+      for _, s in ipairs(shortcuts) do
+        if s.key == c2 then
+          next_state = s.name
+          break
+        end
+      end
+    end
+    if next_state == nil then
+      return
+    end
+    apply_bulk_state(next_state, cur)
+  end
+
+  local count = #targets
+  local mode = (get_cfg().bulk_action_prompt == 'select') and 'select' or 'keys'
+
+  if mode == 'select' then
+    local actions = {
+      { key = 's', label = 'set state' },
+      { key = 'r', label = 'reschedule' },
+      { key = 'd', label = 'deadline' },
+    }
+    vim.ui.select(actions, {
+      prompt = string.format('Bulk (%d) action:', count),
+      format_item = function(item)
+        return string.format('%s = %s', item.key, item.label)
+      end,
+    }, function(choice)
+      if not choice then
+        return
+      end
+      local cur = vim.api.nvim_win_get_cursor(0)
+      if choice.key == 's' then
+        choose_bulk_state_select(cur)
+      elseif choice.key == 'r' then
+        -- bulk reschedule: prompt once via first item, apply result to all
+        bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
+          return hl:set_scheduled()
+        end)
+      elseif choice.key == 'd' then
+        -- bulk deadline: same pattern
+        bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
+          return hl:set_deadline()
+        end)
+      end
     end)
+  else
+    local chunks = {
+      { 'Bulk (' .. count .. '): ', 'Normal' },
+      { 's', 'Comment' },
+      { '=state  ', 'Normal' },
+      { 'r', 'Comment' },
+      { '=reschedule  ', 'Normal' },
+      { 'd', 'Comment' },
+      { '=deadline', 'Normal' },
+    }
+    vim.api.nvim_echo(chunks, false, {})
+    local ok, c = pcall(vim.fn.getcharstr)
+    vim.api.nvim_echo({}, false, {})
+    if not ok then
+      return
+    end
+
+    local cur = vim.api.nvim_win_get_cursor(0)
+    if c == 's' then
+      choose_bulk_state_keys(cur)
+    elseif c == 'r' then
+      -- bulk reschedule: prompt once via first item, apply result to all
+      bulk_apply_date(targets, cur, first_hl, snap_first, 'SCHEDULED', function(hl)
+        return hl:set_scheduled()
+      end)
+    elseif c == 'd' then
+      -- bulk deadline: same pattern
+      bulk_apply_date(targets, cur, first_hl, snap_first, 'DEADLINE', function(hl)
+        return hl:set_deadline()
+      end)
+    end
   end
 end
 

--- a/lua/org-super-agenda/adapters/neovim/highlight.lua
+++ b/lua/org-super-agenda/adapters/neovim/highlight.lua
@@ -10,6 +10,8 @@ function H.ensure()
   pcall(vim.cmd, 'highlight default OrgSA_NONE guifg=#A0A0A0 gui=bold')
   pcall(vim.cmd, 'highlight default OrgSA_Marked guifg=#FFB86C gui=bold')
   pcall(vim.cmd, 'highlight default OrgSA_Clock guifg=#8BE9FD gui=bold')
+  pcall(vim.cmd, 'highlight default link OrgSA_TreeConnector NonText')
+  pcall(vim.cmd, 'highlight default link OrgSA_TreeGhost Comment')
 
   for _, st in ipairs(get_cfg().todo_states or {}) do
     local hl_group = st.hl_group or (type(st.highlight) == 'string' and st.highlight) or ('OrgSA_' .. st.name)

--- a/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
+++ b/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
@@ -6,60 +6,113 @@ local Item = require('org-super-agenda.core.item')
 
 local S = {}
 
--- Load all org files directly from nvim-orgmode (respects org_agenda_files)
+local function normalize_path(path)
+  local absolute = vim.fn.fnamemodify(utils.expand(path), ':p')
+  local normalized = vim.fn.resolve(absolute):gsub('\\', '/')
+  if normalized ~= '/' and not normalized:match('^%a:/$') then
+    normalized = normalized:gsub('/+$', '')
+  end
+  return normalized
+end
+
+local function is_in_directory(path, directory)
+  return path == directory or path:sub(1, #directory + 1) == directory .. '/'
+end
+
+local function load_configured_files(C, org_api)
+  local paths = {}
+  local function add(path)
+    if path and path ~= '' then
+      paths[normalize_path(path)] = true
+    end
+  end
+
+  for _, path in ipairs(C.org_files or {}) do
+    add(path)
+  end
+  for _, directory in ipairs(C.org_directories or {}) do
+    for _, path in ipairs(vim.fn.globpath(utils.expand(directory), '**/*.org', false, true)) do
+      add(path)
+    end
+  end
+
+  local files = {}
+  for path in pairs(paths) do
+    local ok, loaded = pcall(org_api.load, path)
+    if ok and loaded then
+      if loaded.filename or loaded._file then
+        files[#files + 1] = loaded
+      elseif vim.islist(loaded) then
+        vim.list_extend(files, loaded)
+      end
+    end
+  end
+  return files
+end
+
+-- Load configured compatibility overrides, or nvim-orgmode's agenda files.
 local function load_org_files()
   local C = cfg()
 
-  local ok_org, orgmode = pcall(require, 'orgmode')
-  if not ok_org or not orgmode or not orgmode.files or not orgmode.files.load_sync then
+  local ok_api, api_root = pcall(require, 'orgmode.api')
+  local org_api = ok_api and (api_root.load and api_root or api_root.org) or nil
+  if not org_api or not org_api.load then
     error('nvim-orgmode is required but not found. Please install nvim-orgmode/orgmode')
   end
 
-  -- Ensure orgmode has fully loaded agenda files before reading them.
-  -- Without this, orgmode.api.load() can return an empty/partial list on first open.
-  pcall(function()
-    orgmode.files:load_sync(false, 20000)
-  end)
+  local all_files
+  if #(C.org_files or {}) > 0 or #(C.org_directories or {}) > 0 then
+    all_files = load_configured_files(C, org_api)
+  else
+    local ok_org, orgmode = pcall(require, 'orgmode')
+    if not ok_org or not orgmode or not orgmode.files or not orgmode.files.load_sync then
+      error('nvim-orgmode is required but not found. Please install nvim-orgmode/orgmode')
+    end
 
-  local ok_api, org_api = pcall(require, 'orgmode.api')
-  if not ok_api or not org_api or not org_api.load then
-    error('nvim-orgmode is required but not found. Please install nvim-orgmode/orgmode')
-  end
+    -- Ensure orgmode has fully loaded agenda files before reading them.
+    -- Without this, orgmode.api.load() can return an empty/partial list on first open.
+    pcall(function()
+      orgmode.files:load_sync(false, 20000)
+    end)
 
-  -- orgmode.api.load() with no args returns all agenda files already resolved
-  local ok, all_files = pcall(org_api.load)
-  if not ok or not all_files then
-    return {}
+    -- orgmode.api.load() with no args returns all agenda files already resolved.
+    local ok, loaded = pcall(org_api.load)
+    if not ok or not loaded then
+      return {}
+    end
+    all_files = loaded
   end
 
   -- Build exclusion set
   local skip = {}
   for _, f in ipairs(C.exclude_files or {}) do
     if f and f ~= '' then
-      skip[utils.expand(f)] = true
+      skip[normalize_path(f)] = true
     end
   end
   local skip_dirs = {}
   for _, d in ipairs(C.exclude_directories or {}) do
     if d and d ~= '' then
-      skip_dirs[#skip_dirs + 1] = utils.expand(d)
+      skip_dirs[#skip_dirs + 1] = normalize_path(d)
     end
   end
 
   local files = {}
   for _, f in ipairs(all_files) do
     local path = f.filename or (f._file and f._file.filename)
-    if path and not skip[path] then
+    local normalized_path = path and normalize_path(path) or nil
+    if normalized_path and not skip[normalized_path] then
       local excluded = false
       for _, d in ipairs(skip_dirs) do
-        if path:find('^' .. vim.pesc(d)) then
+        if is_in_directory(normalized_path, d) then
           excluded = true
           break
         end
       end
       if not excluded then
         if f.reload then
-          files[#files + 1] = f:reload()
+          local reloaded = f:reload()
+          files[#files + 1] = reloaded or f
         else
           files[#files + 1] = f
         end

--- a/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
+++ b/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
@@ -6,60 +6,52 @@ local Item = require('org-super-agenda.core.item')
 
 local S = {}
 
--- Utility: expand directories/files declared in config and load orgmode files
+-- Load all org files directly from nvim-orgmode (respects org_agenda_files)
 local function load_org_files()
   local C = cfg()
-  local want, skip = {}, {}
-  local function add(tbl, k)
-    if k and k ~= '' then
-      tbl[utils.expand(k)] = true
-    end
+
+  local ok_api, org_api = pcall(require, 'orgmode.api')
+  if not ok_api or not org_api or not org_api.load then
+    error('nvim-orgmode is required but not found. Please install nvim-orgmode/orgmode')
   end
 
-  for _, f in ipairs(C.org_files or {}) do
-    add(want, f)
+  -- orgmode.api.load() with no args returns all agenda files already resolved
+  local ok, all_files = pcall(org_api.load)
+  if not ok or not all_files then
+    return {}
   end
-  for _, d in ipairs(C.org_directories or {}) do
-    for _, f in ipairs(utils.get_org_files(d)) do
-      add(want, f)
-    end
-  end
+
+  -- Build exclusion set
+  local skip = {}
   for _, f in ipairs(C.exclude_files or {}) do
-    add(skip, f)
-  end
-  for _, d in ipairs(C.exclude_directories or {}) do
-    for p in pairs(want) do
-      if p:find('^' .. vim.pesc(utils.expand(d))) then
-        skip[p] = true
-      end
+    if f and f ~= '' then
+      skip[utils.expand(f)] = true
     end
   end
-
-  local ok_api, api_root = pcall(require, 'orgmode.api')
-  if not ok_api then
-    return {}
-  end
-  local org_api = api_root.load and api_root or api_root.org
-  if not (org_api and org_api.load) then
-    return {}
+  local skip_dirs = {}
+  for _, d in ipairs(C.exclude_directories or {}) do
+    if d and d ~= '' then
+      skip_dirs[#skip_dirs + 1] = utils.expand(d)
+    end
   end
 
   local files = {}
-  for path in pairs(want) do
-    if not skip[path] then
-      local ok, f = pcall(org_api.load, path)
-      if ok and f then
-        if f.filename or f._file then
-          files[#files + 1] = f
-        elseif vim.islist(f) then
-          vim.list_extend(files, f)
+  for _, f in ipairs(all_files) do
+    local path = f.filename or (f._file and f._file.filename)
+    if path and not skip[path] then
+      local excluded = false
+      for _, d in ipairs(skip_dirs) do
+        if path:find('^' .. vim.pesc(d)) then
+          excluded = true
+          break
         end
+      end
+      if not excluded then
+        files[#files + 1] = f
       end
     end
   end
-  for i, f in ipairs(files) do
-    files[i] = f:reload()
-  end
+
   return files
 end
 

--- a/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
+++ b/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
@@ -244,12 +244,29 @@ function S.collect()
 
   local items = {}
 
-  -- Walk the tree, passing accumulated (inherited) tags downwards
-  local function walk(hl, inherited_tags)
+  -- Walk the tree, passing accumulated (inherited) tags and ancestry downwards
+  local function walk(hl, inherited_tags, ancestry)
     local all_tags = merge_tags(inherited_tags, hl.tags or {})
-    items[#items + 1] = headline_to_item(hl, inherited_tags)
+    local item = headline_to_item(hl, inherited_tags)
+    -- ancestor chain, nearest parent first (used by the tree view)
+    local parents = {}
+    for i = #ancestry, 1, -1 do
+      parents[#parents + 1] = ancestry[i]
+    end
+    item.parents = parents
+    items[#items + 1] = item
+
+    local child_ancestry = vim.list_slice(ancestry, 1, #ancestry)
+    child_ancestry[#child_ancestry + 1] = {
+      key = string.format('%s:%s', item.file or '', item._src_line or 0),
+      headline = hl.title,
+      level = hl.level,
+      todo_state = hl.todo_value,
+      file = item.file,
+      _src_line = item._src_line,
+    }
     for _, c in ipairs(hl.headlines or {}) do
-      walk(c, all_tags)
+      walk(c, all_tags, child_ancestry)
     end
   end
 
@@ -268,7 +285,7 @@ function S.collect()
 
     for _, hl in ipairs(file.headlines or {}) do
       -- Top-level headlines inherit filetags
-      walk(hl, filetags)
+      walk(hl, filetags, {})
     end
   end
 

--- a/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
+++ b/lua/org-super-agenda/adapters/neovim/source_orgmode.lua
@@ -10,6 +10,17 @@ local S = {}
 local function load_org_files()
   local C = cfg()
 
+  local ok_org, orgmode = pcall(require, 'orgmode')
+  if not ok_org or not orgmode or not orgmode.files or not orgmode.files.load_sync then
+    error('nvim-orgmode is required but not found. Please install nvim-orgmode/orgmode')
+  end
+
+  -- Ensure orgmode has fully loaded agenda files before reading them.
+  -- Without this, orgmode.api.load() can return an empty/partial list on first open.
+  pcall(function()
+    orgmode.files:load_sync(false, 20000)
+  end)
+
   local ok_api, org_api = pcall(require, 'orgmode.api')
   if not ok_api or not org_api or not org_api.load then
     error('nvim-orgmode is required but not found. Please install nvim-orgmode/orgmode')
@@ -47,7 +58,11 @@ local function load_org_files()
         end
       end
       if not excluded then
-        files[#files + 1] = f
+        if f.reload then
+          files[#files + 1] = f:reload()
+        else
+          files[#files + 1] = f
+        end
       end
     end
   end

--- a/lua/org-super-agenda/adapters/neovim/utils.lua
+++ b/lua/org-super-agenda/adapters/neovim/utils.lua
@@ -6,18 +6,6 @@ function U.expand(path)
   return (path:gsub('^~', vim.fn.expand('$HOME')))
 end
 
-function U.get_org_files(dir)
-  local res, cmd = {}, string.format('find %q -type f -name "*.org"', U.expand(dir))
-  local handle = io.popen(cmd)
-  if handle then
-    for f in handle:lines() do
-      res[#res + 1] = f
-    end
-    handle:close()
-  end
-  return res
-end
-
 function U.show_help()
   local cfg = get_cfg()
   local km = cfg.keymaps or {}

--- a/lua/org-super-agenda/adapters/neovim/utils.lua
+++ b/lua/org-super-agenda/adapters/neovim/utils.lua
@@ -101,7 +101,7 @@ function U.show_help()
 
   local ui = vim.api.nvim_list_uis()[1]
   local h, w = #out + 2, 60
-  vim.api.nvim_open_win(buf, true, {
+  local win = vim.api.nvim_open_win(buf, true, {
     relative = 'editor',
     style = 'minimal',
     border = 'rounded',
@@ -113,6 +113,7 @@ function U.show_help()
   })
 
   local function close()
+    pcall(vim.api.nvim_win_close, win, true)
     pcall(vim.api.nvim_buf_delete, buf, { force = true })
   end
   for _, k in ipairs({ 'g?', 'q', '<Esc>' }) do

--- a/lua/org-super-agenda/adapters/neovim/utils.lua
+++ b/lua/org-super-agenda/adapters/neovim/utils.lua
@@ -69,7 +69,7 @@ function U.show_help()
     fmt(km.undo, 'Undo'),
     fmt(km.toggle_other, 'Toggle "Other" group'),
     fmt(km.toggle_duplicates, 'Toggle duplicates'),
-    fmt(km.cycle_view, 'Switch view (classic/compact)'),
+    fmt(km.cycle_view, 'Switch view (classic/compact/tree)'),
     fmt(km.hide_item, 'Hide headline from agenda'),
     fmt(km.reset_hidden, 'Reset hide'),
     fmt(km.fold_all, 'Fold all groups'),

--- a/lua/org-super-agenda/app/pipeline.lua
+++ b/lua/org-super-agenda/app/pipeline.lua
@@ -5,6 +5,7 @@ local sort_core = require('org-super-agenda.core.sort')
 local views_core = require('org-super-agenda.core.views')
 local layout_classic = require('org-super-agenda.core.layout.classic')
 local layout_compact = require('org-super-agenda.core.layout.compact')
+local layout_tree = require('org-super-agenda.core.layout.tree')
 
 local Pipeline = {}
 
@@ -76,8 +77,14 @@ function Pipeline.run(source, cfg, state)
     }
   end
 
-  -- choose layout
-  local layout = (state.view_mode == 'compact') and layout_compact or layout_classic
+  -- choose layout (an active custom view may override the session view mode)
+  local mode = (active_view and active_view.view_mode) or state.view_mode
+  local layout = layout_classic
+  if mode == 'compact' then
+    layout = layout_compact
+  elseif mode == 'tree' then
+    layout = layout_tree
+  end
 
   return function(win_width)
     return layout.build(groups, win_width, cfg, state.marked)

--- a/lua/org-super-agenda/app/services.lua
+++ b/lua/org-super-agenda/app/services.lua
@@ -94,7 +94,8 @@ end
 function Services.agenda.cycle_view()
   local cur = view.is_open() and vim.api.nvim_win_get_cursor(0) or nil
   local m = store.get().view_mode
-  store.set_view_mode(m == 'classic' and 'compact' or 'classic')
+  local next_mode = { classic = 'compact', compact = 'tree', tree = 'classic' }
+  store.set_view_mode(next_mode[m] or 'classic')
   if cur then
     Services.agenda.refresh(cur)
   else

--- a/lua/org-super-agenda/config.lua
+++ b/lua/org-super-agenda/config.lua
@@ -165,13 +165,17 @@ M.defaults = {
   heading_max_length = 70,
   persist_hidden = false,
   fold_item_action = 'preview',
-  view_mode = 'classic',
+  view_mode = 'classic', -- 'classic' | 'compact' | 'tree'
   classic = {
     heading_order = { 'filename', 'todo', 'priority', 'headline' },
     short_date_labels = false,
     inline_dates = true,
   },
   compact = { filename_min_width = 10, label_min_width = 12 },
+  -- Tree view: renders each group's items hierarchically (subtasks nested
+  -- under their parent). show_ghost_parents inserts dimmed context rows for
+  -- ancestors that are not part of the group themselves.
+  tree = { show_ghost_parents = true },
 
   -- Global fallback sort for groups that don't specify their own `sort`
   group_sort = { by = 'date_nearest', order = 'asc' },

--- a/lua/org-super-agenda/config.lua
+++ b/lua/org-super-agenda/config.lua
@@ -2,6 +2,10 @@
 local M = {}
 
 M.defaults = {
+  -- Optional compatibility overrides. When empty, files come from
+  -- nvim-orgmode's org_agenda_files configuration.
+  org_files = {},
+  org_directories = {},
   exclude_files = {},
   exclude_directories = {},
   keymaps = {

--- a/lua/org-super-agenda/config.lua
+++ b/lua/org-super-agenda/config.lua
@@ -158,6 +158,10 @@ M.defaults = {
   show_other_group = false,
   show_tags = true,
   show_filename = true,
+  -- How bulk action prompts are shown:
+  --   'keys'   = inline key hints + getchar (fast keyboard flow)
+  --   'select' = vim.ui.select picker (better with UI routers like noice.nvim)
+  bulk_action_prompt = 'keys',
   heading_max_length = 70,
   persist_hidden = false,
   fold_item_action = 'preview',

--- a/lua/org-super-agenda/config.lua
+++ b/lua/org-super-agenda/config.lua
@@ -2,8 +2,6 @@
 local M = {}
 
 M.defaults = {
-  org_files = {},
-  org_directories = {},
   exclude_files = {},
   exclude_directories = {},
   keymaps = {

--- a/lua/org-super-agenda/core/layout/classic.lua
+++ b/lua/org-super-agenda/core/layout/classic.lua
@@ -8,11 +8,17 @@ local function truncate(str, len)
   return str:sub(1, len)
 end
 
+local function file_stem(path)
+  local p = (path or ''):gsub('\\', '/')
+  local base = p:match('[^/]+$') or ''
+  return base:gsub('%.org$', '')
+end
+
 local function classic_prefix(it, cfg)
   local indent = '  ' .. string.rep(' ', it.level or 0)
   local pri = (it.priority and it.priority ~= '') and ('[#' .. it.priority .. ']') or nil
   local parts = {
-    filename = (cfg.show_filename and it.file) and (it.file:match('[^/]+$') or ''):gsub('%.org$', ''),
+    filename = (cfg.show_filename and it.file) and file_stem(it.file),
     todo = it.todo_state,
     priority = pri,
     headline = truncate(it.headline or '', cfg.heading_max_length),
@@ -91,7 +97,7 @@ function L.build(groups, win_width, cfg, marked)
           local meta_str = table.concat(meta, ' ')
 
           local parts = {
-            filename = (cfg.show_filename and it.file) and (it.file:match('[^/]+$') or ''):gsub('%.org$', ''),
+            filename = (cfg.show_filename and it.file) and file_stem(it.file),
             todo = it.todo_state,
             priority = pri,
             headline = truncate(it.headline or '', cfg.heading_max_length),

--- a/lua/org-super-agenda/core/layout/compact.lua
+++ b/lua/org-super-agenda/core/layout/compact.lua
@@ -8,6 +8,12 @@ local function truncate(str, len)
   return str:sub(1, len)
 end
 
+local function file_stem(path)
+  local p = (path or ''):gsub('\\', '/')
+  local base = p:match('[^/]+$') or ''
+  return base:gsub('%.org$', '')
+end
+
 local MARK_GLYPH = '● '
 local CLOCK_GLYPH = '⏱ '
 local function item_key(it)
@@ -49,7 +55,7 @@ function L.build(groups, win_width, cfg, marked)
 
   for _, grp in ipairs(groups) do
     for _, it in ipairs(grp.items) do
-      local name = ((it.file or ''):match('[^/]+$') or ''):gsub('%.org$', '') .. ':'
+      local name = file_stem(it.file) .. ':'
       if #name > fname_w then
         fname_w = #name
       end
@@ -72,7 +78,7 @@ function L.build(groups, win_width, cfg, marked)
 
       if not grp.collapsed then
         for _, it in ipairs(grp.items) do
-          local name = (((it.file or ''):match('[^/]+$') or ''):gsub('%.org$', '') .. ':')
+          local name = file_stem(it.file) .. ':'
           local label = build_labels(it)
           if label == '' then
             label = string.rep(' ', label_w)
@@ -92,6 +98,7 @@ function L.build(groups, win_width, cfg, marked)
           local s_fn = #text
           text = text .. string.format('%-' .. fname_w .. 's', name)
           spans[#spans + 1] = { field = 'filename', s = s_fn, e = #text, state = it.todo_state }
+          text = text .. ' '
           local s_lab = #text
           text = text .. label
           spans[#spans + 1] = { field = 'date', s = s_lab, e = #text, state = it.todo_state }

--- a/lua/org-super-agenda/core/layout/tree.lua
+++ b/lua/org-super-agenda/core/layout/tree.lua
@@ -1,0 +1,291 @@
+-- core/layout/tree.lua -- pure rows/hls/line_map; hierarchical (parent → subtask) rendering
+local L = {}
+
+local function truncate(str, len)
+  if not len or #str <= len then
+    return str
+  end
+  return str:sub(1, len)
+end
+
+local function file_stem(path)
+  local p = (path or ''):gsub('\\', '/')
+  local base = p:match('[^/]+$') or ''
+  return base:gsub('%.org$', '')
+end
+
+local MARK_GLYPH = '● '
+local CLOCK_GLYPH = '⏱ '
+local BRANCH_MID = '├─ '
+local BRANCH_LAST = '└─ '
+local BAR_CONT = '│  '
+local BAR_NONE = '   '
+
+local function dwidth(s)
+  return vim.fn.strdisplaywidth(s)
+end
+
+local function item_key(it)
+  return string.format('%s:%s', it.file or '', it._src_line or 0)
+end
+
+local function header_label(cfg, grp)
+  local n = #grp.items
+  local count = string.format('%d %s', n, (n == 1) and 'item' or 'items')
+  return string.format((cfg.group_format or '* %s') .. ' (%s)', grp.name, count)
+end
+
+-- Build a forest from one group's items using each item's `parents` chain
+-- (nearest ancestor first). An item nests under the closest ancestor that is
+-- itself part of the group; when `show_ghosts` is set, ancestors that are NOT
+-- part of the group are inserted as dimmed context nodes so the hierarchy
+-- stays readable (e.g. subtasks scheduled today under an unscheduled project).
+local function build_forest(items, show_ghosts)
+  local nodes, roots, ghosts = {}, {}, {}
+  for _, it in ipairs(items) do
+    nodes[item_key(it)] = { item = it, children = {} }
+  end
+
+  local resolve
+  local function ghost_node(anc, rest)
+    if ghosts[anc.key] then
+      return ghosts[anc.key]
+    end
+    local node = {
+      item = {
+        _ghost = true,
+        headline = anc.headline,
+        todo_state = anc.todo_state,
+        level = anc.level,
+        file = anc.file,
+        _src_line = anc._src_line,
+      },
+      children = {},
+      ghost = true,
+    }
+    ghosts[anc.key] = node
+    local parent = resolve(rest)
+    if parent then
+      parent.children[#parent.children + 1] = node
+    else
+      roots[#roots + 1] = node
+    end
+    return node
+  end
+
+  -- parents: remaining ancestor chain, nearest first -> parent node or nil (root)
+  resolve = function(parents)
+    for i, anc in ipairs(parents or {}) do
+      if nodes[anc.key] then
+        return nodes[anc.key]
+      end
+      if show_ghosts then
+        return ghost_node(anc, vim.list_slice(parents, i + 1, #parents))
+      end
+    end
+    return nil
+  end
+
+  for _, it in ipairs(items) do
+    local node = nodes[item_key(it)]
+    local parent = resolve(it.parents)
+    if parent then
+      parent.children[#parent.children + 1] = node
+    else
+      roots[#roots + 1] = node
+    end
+  end
+  return roots
+end
+
+-- Depth-first flatten; each entry carries its branch prefix ("│  └─ ") and
+-- the continuation prefix ("│     ") used for wrapped meta lines below it.
+local function flatten(forest)
+  local out = {}
+  local function visit(node, branch, cont)
+    out[#out + 1] = { node = node, branch = branch, cont = cont }
+    for i, c in ipairs(node.children) do
+      local last = (i == #node.children)
+      visit(c, cont .. (last and BRANCH_LAST or BRANCH_MID), cont .. (last and BAR_NONE or BAR_CONT))
+    end
+  end
+  for _, r in ipairs(forest) do
+    visit(r, '', '')
+  end
+  return out
+end
+
+local function build_parts(it, cfg, has_visible_children)
+  local pri = (it.priority and it.priority ~= '') and ('[#' .. it.priority .. ']') or nil
+  local parts = {
+    filename = (cfg.show_filename and it.file) and file_stem(it.file),
+    todo = it.todo_state,
+    priority = pri,
+    headline = truncate(it.headline or '', cfg.heading_max_length),
+  }
+  -- "…" only when the extra content is not already visible as subtasks
+  if it.has_more and not has_visible_children then
+    parts.headline = (parts.headline or '') .. ' …'
+  end
+  return parts
+end
+
+local function tokens(it, cfg, has_visible_children)
+  local parts = build_parts(it, cfg, has_visible_children)
+  local order = vim.deepcopy(cfg.classic.heading_order or { 'filename', 'todo', 'priority', 'headline' })
+  local tok = {}
+  if parts.filename and order[1] == 'filename' then
+    tok[#tok + 1] = { field = 'filename', txt = '[' .. parts.filename .. ']' }
+    table.remove(order, 1)
+  end
+  for _, k in ipairs(order) do
+    if parts[k] and parts[k] ~= '' then
+      tok[#tok + 1] = { field = k, txt = parts[k] }
+    end
+  end
+  return tok
+end
+
+function L.build(groups, win_width, cfg, marked)
+  local rows, hls, line_map = {}, {}, {}
+  local show_ghosts = not (cfg.tree and cfg.tree.show_ghost_parents == false)
+
+  local flat = {}
+  for gi, g in ipairs(groups) do
+    flat[gi] = flatten(build_forest(g.items, show_ghosts))
+  end
+
+  -- widest prefix (display width) across all groups for inline date alignment
+  local widest = 0
+  for _, entries in ipairs(flat) do
+    for _, e in ipairs(entries) do
+      if not e.node.ghost then
+        local tok = {}
+        for _, t in ipairs(tokens(e.node.item, cfg, #e.node.children > 0)) do
+          tok[#tok + 1] = t.txt
+        end
+        widest = math.max(widest, dwidth('  ' .. e.branch .. table.concat(tok, ' ')))
+      end
+    end
+  end
+  widest = widest + 1
+
+  local ln = 0
+  local function emit(s)
+    ln = ln + 1
+    rows[ln] = s
+    return ln
+  end
+
+  for gi, grp in ipairs(groups) do
+    if #grp.items > 0 then
+      emit('')
+      local hdln = emit(header_label(cfg, grp))
+      line_map[hdln] = { _kind = 'group_header', group_name = grp.name }
+      hls[#hls + 1] = { hdln - 1, 0, -1, 'OrgSA_Group' }
+
+      if not grp.collapsed then
+        for _, entry in ipairs(flat[gi]) do
+          local node, it = entry.node, entry.node.item
+
+          if node.ghost then
+            local indent = '  '
+            local text = indent .. entry.branch
+            local branch_s, branch_e = #indent, #text
+            local label = (it.todo_state and it.todo_state ~= '' and (it.todo_state .. ' ') or '') .. (it.headline or '')
+            local lnum = emit(text .. label)
+            line_map[lnum] = it
+            if branch_e > branch_s then
+              hls[#hls + 1] = { lnum - 1, branch_s, branch_e, 'OrgSA_TreeConnector' }
+            end
+            hls[#hls + 1] = { lnum - 1, branch_e, -1, 'OrgSA_TreeGhost' }
+          else
+            local is_marked = marked and marked[item_key(it)]
+            local clock_pfx = it.clocked_in and CLOCK_GLYPH or ''
+            local indent = (is_marked and MARK_GLYPH or '  ') .. clock_pfx
+            local text = indent .. entry.branch
+            local branch_s, branch_e = #indent, #text
+
+            local spans = {}
+            local function push(field, txt)
+              if not txt or txt == '' then
+                return
+              end
+              if #text > 0 and text:sub(-1) ~= ' ' then
+                text = text .. ' '
+              end
+              local s = #text
+              text = text .. txt
+              spans[#spans + 1] = { field = field, s = s, e = #text, state = it.todo_state }
+            end
+
+            for _, t in ipairs(tokens(it, cfg, #node.children > 0)) do
+              push(t.field, t.txt)
+            end
+
+            local sched_label = cfg.classic.short_date_labels and 'S' or 'SCHEDULED'
+            local dead_label = cfg.classic.short_date_labels and 'D' or 'DEADLINE'
+            local meta = {}
+            if it.scheduled then
+              meta[#meta + 1] = sched_label .. ': <' .. tostring(it.scheduled) .. '>'
+            end
+            if it.deadline then
+              meta[#meta + 1] = dead_label .. ':  <' .. tostring(it.deadline) .. '>'
+            end
+            local meta_str = table.concat(meta, ' ')
+
+            if cfg.classic.inline_dates and meta_str ~= '' then
+              local w = dwidth(text)
+              text = text .. string.rep(' ', math.max(widest - w, 1))
+              local ms = #text
+              text = text .. meta_str
+              spans[#spans + 1] = { field = 'date', s = ms, e = #text, state = it.todo_state }
+            end
+
+            if cfg.show_tags and it.tags and #it.tags > 0 then
+              local tag = ':' .. table.concat(it.tags, ':') .. ':'
+              local start = win_width - dwidth(tag) - 1
+              local w = dwidth(text)
+              if w + 1 < start then
+                text = text .. string.rep(' ', start - w) .. tag
+              else
+                text = text .. ' ' .. tag
+              end
+              spans[#spans + 1] = { field = 'tags', s = #text - #tag, e = #text, state = it.todo_state }
+            end
+
+            local lnum = emit(text)
+            line_map[lnum] = it
+
+            if branch_e > branch_s then
+              hls[#hls + 1] = { lnum - 1, branch_s, branch_e, 'OrgSA_TreeConnector' }
+            end
+            for _, sp in ipairs(spans) do
+              hls[#hls + 1] = { lnum - 1, sp.s, sp.e, nil, field = sp.field, state = sp.state }
+            end
+            if is_marked then
+              hls[#hls + 1] = { lnum - 1, 0, #MARK_GLYPH, 'OrgSA_Marked', field = 'mark', state = it.todo_state }
+            end
+            if it.clocked_in then
+              local cstart = is_marked and #MARK_GLYPH or 2
+              hls[#hls + 1] = { lnum - 1, cstart, cstart + #CLOCK_GLYPH, 'OrgSA_Clock', field = 'clock', state = it.todo_state }
+            end
+
+            if not cfg.classic.inline_dates and meta_str ~= '' then
+              local cont = '  ' .. entry.cont
+              local mln = emit(cont .. '  ' .. meta_str)
+              if #entry.cont > 0 then
+                hls[#hls + 1] = { mln - 1, 2, #cont, 'OrgSA_TreeConnector' }
+              end
+              hls[#hls + 1] = { mln - 1, #cont + 2, -1, nil, field = 'date', state = it.todo_state }
+            end
+          end
+        end
+      end
+    end
+  end
+
+  return rows, hls, line_map
+end
+
+return L

--- a/tests/helpers/min.lua
+++ b/tests/helpers/min.lua
@@ -8,7 +8,12 @@ package.path = table.concat({
 
 -- --- orgmode‑Stubs ----------------------------------------------------
 package.preload['orgmode'] = function()
-  return { reload = function() end }
+  return {
+    reload = function() end,
+    config = {
+      org_agenda_files = {},
+    },
+  }
 end
 package.preload['orgmode.api'] = function()
   local function load(_)
@@ -17,10 +22,7 @@ package.preload['orgmode.api'] = function()
   return { load = load, org = { load = load } }
 end
 
-require('org-super-agenda').setup({
-  org_files = {},
-  org_directories = {},
-})
+require('org-super-agenda').setup({})
 
 if vim.islist == nil then
   vim.islist = vim.tbl_islist

--- a/tests/repeat_tasks_spec.lua
+++ b/tests/repeat_tasks_spec.lua
@@ -1,0 +1,291 @@
+local Actions = require('org-super-agenda.adapters.neovim.actions')
+local Store = require('org-super-agenda.app.store')
+local Services = require('org-super-agenda.app.services')
+local config = require('org-super-agenda.config')
+
+describe('repeat task support', function()
+  local original_state
+  local original_refresh
+  local original_notify
+  local original_loaded = {}
+  local temp_files = {}
+  local refresh_calls = 0
+  local notifications = {}
+
+  local module_names = {
+    'orgmode',
+    'orgmode.api',
+    'orgmode.config',
+    'orgmode.objects.date',
+    'orgmode.objects.todo_state',
+  }
+
+  local function write_temp_org(lines)
+    local path = vim.fn.tempname() .. '.org'
+    vim.fn.writefile(lines, path)
+    temp_files[#temp_files + 1] = path
+    return path
+  end
+
+  local function setup_agenda_buffer(path)
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_win_set_buf(0, buf)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'agenda row' })
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    Actions.set_keymaps(buf, vim.api.nvim_get_current_win(), { [1] = { file = path, _src_line = 1 } }, function() end)
+    return buf
+  end
+
+  local function invoke_buffer_mapping(lhs)
+    local map = vim.fn.maparg(lhs, 'n', false, true)
+    assert.is_truthy(map)
+    assert.is_truthy(map.callback)
+    map.callback()
+  end
+
+  local function setup_fake_org(opts)
+    local path = opts.path
+    local todo = opts.todo or 'TODO'
+    local replaced = {}
+
+    local kw_todo = { value = 'TODO', type = 'TODO', index = 1, sequence_index = 1 }
+    local kw_done = { value = 'DONE', type = 'DONE', index = 2, sequence_index = 1 }
+    local todo_keywords = {
+      find = function(_, value)
+        if value == 'TODO' then
+          return kw_todo
+        end
+        if value == 'DONE' then
+          return kw_done
+        end
+      end,
+      all = function()
+        return { kw_todo, kw_done }
+      end,
+    }
+
+    local internal_file = {
+      filename = path,
+      get_todo_keywords = function()
+        return todo_keywords
+      end,
+    }
+
+    local internal = {
+      file = internal_file,
+      todo = todo,
+      properties = {},
+      notes = {},
+      repeater_dates = opts.repeater_dates or {},
+      closed_set = false,
+      get_todo = function(self)
+        return self.todo
+      end,
+      is_done = function(self)
+        return self.todo == 'DONE'
+      end,
+      set_todo = function(self, keyword)
+        self.todo = keyword
+      end,
+      get_repeater_dates = function(self)
+        return self.repeater_dates
+      end,
+      set_closed_date = function(self)
+        self.closed_set = true
+      end,
+      remove_closed_date = function(self)
+        self.closed_set = false
+      end,
+      set_property = function(self, key, value)
+        self.properties[key] = value
+      end,
+      add_note = function(self, note)
+        table.insert(self.notes, note)
+      end,
+      get_indent = function()
+        return ''
+      end,
+    }
+
+    local api_headline = {
+      file = { filename = path },
+      position = { start_line = 1, end_line = 1 },
+      todo_value = todo,
+      todo_type = todo_keywords:find(todo).type,
+      properties = {},
+      _section = internal,
+    }
+
+    function api_headline:reload()
+      self.todo_value = internal:get_todo()
+      local kw = todo_keywords:find(self.todo_value)
+      self.todo_type = kw and kw.type or ''
+      self.properties = vim.deepcopy(internal.properties)
+      return self
+    end
+
+    function api_headline:_do_action(action)
+      return {
+        wait = function()
+          action()
+          return self:reload()
+        end,
+      }
+    end
+
+    local fake_instance = {
+      files = {
+        get_closest_headline = function()
+          return internal
+        end,
+      },
+      org_mappings = {
+        _replace_date = function(_, date)
+          table.insert(replaced, date.kind)
+        end,
+      },
+    }
+
+    package.loaded['orgmode'] = {
+      instance = function()
+        return fake_instance
+      end,
+    }
+
+    package.loaded['orgmode.api'] = {
+      load = function(requested)
+        if requested == path then
+          return {
+            get_headline_on_line = function(_, line)
+              if line == 1 then
+                return api_headline
+              end
+            end,
+          }
+        end
+        return {}
+      end,
+      org = {},
+    }
+
+    package.loaded['orgmode.config'] = {
+      org_log_repeat = true,
+      org_log_done = 'time',
+    }
+
+    package.loaded['orgmode.objects.date'] = {
+      now = function()
+        return {
+          to_wrapped_string = function()
+            return '[2026-04-11 Fri 12:00]'
+          end,
+          to_string = function()
+            return '2026-04-11 Fri 12:00'
+          end,
+        }
+      end,
+    }
+
+    package.loaded['orgmode.objects.todo_state'] = {
+      new = function(_, _)
+        return {
+          get_reset_todo = function()
+            return kw_todo
+          end,
+        }
+      end,
+    }
+
+    return {
+      api_headline = api_headline,
+      internal = internal,
+      replaced = replaced,
+    }
+  end
+
+  before_each(function()
+    original_state = vim.deepcopy(Store.state)
+    original_refresh = Services.agenda.refresh
+    original_notify = vim.notify
+    refresh_calls = 0
+    notifications = {}
+    temp_files = {}
+
+    for _, name in ipairs(module_names) do
+      original_loaded[name] = package.loaded[name]
+    end
+
+    Services.agenda.refresh = function()
+      refresh_calls = refresh_calls + 1
+    end
+    vim.notify = function(msg)
+      notifications[#notifications + 1] = msg
+    end
+
+    Store.state = vim.deepcopy(original_state)
+    config.setup(vim.deepcopy(config.defaults))
+  end)
+
+  after_each(function()
+    Services.agenda.refresh = original_refresh
+    vim.notify = original_notify
+    Store.state = vim.deepcopy(original_state)
+    config.setup(vim.deepcopy(config.defaults))
+
+    for _, name in ipairs(module_names) do
+      package.loaded[name] = original_loaded[name]
+    end
+
+    for _, path in ipairs(temp_files) do
+      pcall(vim.fn.delete, path)
+    end
+  end)
+
+  it('advances repeater metadata and resets to TODO when marking a repeating task done', function()
+    local path = write_temp_org({ '* TODO Weekly review' })
+    local env = setup_fake_org({
+      path = path,
+      repeater_dates = {
+        {
+          kind = 'scheduled',
+          apply_repeater = function(self)
+            return { kind = self.kind }
+          end,
+        },
+        {
+          kind = 'deadline',
+          apply_repeater = function(self)
+            return { kind = self.kind }
+          end,
+        },
+      },
+    })
+
+    setup_agenda_buffer(path)
+    invoke_buffer_mapping('sd')
+
+    assert.are.same({ 'scheduled', 'deadline' }, env.replaced)
+    assert.equals('TODO', env.internal.todo)
+    assert.equals('[2026-04-11 Fri 12:00]', env.internal.properties.LAST_REPEAT)
+    assert.equals(1, #env.internal.notes)
+    assert.is_true(env.internal.notes[1][1]:find('State ') ~= nil)
+    assert.is_false(Store.sticky_has(path .. ':1'))
+    assert.equals(1, refresh_calls)
+    assert.are.same({}, notifications)
+  end)
+
+  it('keeps non-repeating tasks as DONE and records sticky state', function()
+    local path = write_temp_org({ '* TODO One-off task' })
+    local env = setup_fake_org({ path = path, repeater_dates = {} })
+
+    setup_agenda_buffer(path)
+    invoke_buffer_mapping('sd')
+
+    assert.are.same({}, env.replaced)
+    assert.equals('DONE', env.internal.todo)
+    assert.is_true(env.internal.closed_set)
+    assert.is_true(Store.sticky_has(path .. ':1'))
+    assert.equals(1, refresh_calls)
+    assert.are.same({}, notifications)
+  end)
+end)

--- a/tests/source_orgmode_spec.lua
+++ b/tests/source_orgmode_spec.lua
@@ -1,0 +1,226 @@
+local config = require('org-super-agenda.config')
+local source = require('org-super-agenda.adapters.neovim.source_orgmode')
+
+describe('orgmode source files', function()
+  local defaults = vim.deepcopy(config.defaults)
+  local original_orgmode
+  local original_api
+  local temp_paths = {}
+
+  local function temp_directory()
+    local directory = vim.fn.tempname()
+    vim.fn.mkdir(directory, 'p')
+    temp_paths[#temp_paths + 1] = directory
+    return directory
+  end
+
+  local function write_org(directory, name)
+    vim.fn.mkdir(directory, 'p')
+    local path = directory .. '/' .. name
+    vim.fn.writefile({ '* TODO Test task' }, path)
+    return path
+  end
+
+  local function org_file(path)
+    local internal = {
+      filename = path,
+      get_filetags = function()
+        return {}
+      end,
+    }
+    local file = {
+      filename = path,
+      _file = internal,
+      headlines = {
+        {
+          title = 'Test task',
+          level = 1,
+          tags = {},
+          todo_value = 'TODO',
+          properties = {},
+          file = { filename = path },
+          position = { start_line = 1 },
+          headlines = {},
+        },
+      },
+    }
+    function file:reload()
+      return self
+    end
+    return file
+  end
+
+  before_each(function()
+    original_orgmode = package.loaded['orgmode']
+    original_api = package.loaded['orgmode.api']
+    config.setup(vim.deepcopy(defaults))
+  end)
+
+  after_each(function()
+    package.loaded['orgmode'] = original_orgmode
+    package.loaded['orgmode.api'] = original_api
+    for _, path in ipairs(temp_paths) do
+      vim.fn.delete(path, 'rf')
+    end
+    temp_paths = {}
+    config.setup(vim.deepcopy(defaults))
+  end)
+
+  it('uses nvim-orgmode agenda files by default', function()
+    local directory = temp_directory()
+    local path = write_org(directory, 'agenda.org')
+    local file = org_file(path)
+    local load_sync_calls = 0
+
+    package.loaded['orgmode'] = {
+      files = {
+        load_sync = function()
+          load_sync_calls = load_sync_calls + 1
+        end,
+      },
+    }
+    package.loaded['orgmode.api'] = {
+      load = function(requested)
+        assert.is_nil(requested)
+        return { file }
+      end,
+    }
+
+    local items = source.collect()
+
+    assert.equals(1, load_sync_calls)
+    assert.equals(1, #items)
+    assert.equals(path, items[1].file)
+  end)
+
+  it('keeps org_files as an explicit compatibility override', function()
+    local directory = temp_directory()
+    local path = write_org(directory, 'explicit.org')
+    local file = org_file(path)
+    local requested_paths = {}
+
+    config.setup({ org_files = { path } })
+    package.loaded['orgmode'] = {
+      files = {
+        load_sync = function()
+          error('agenda files should not load when an override is configured')
+        end,
+      },
+    }
+    package.loaded['orgmode.api'] = {
+      load = function(requested)
+        requested_paths[#requested_paths + 1] = requested
+        return file
+      end,
+    }
+
+    local items = source.collect()
+
+    assert.same({ vim.fn.resolve(path) }, requested_paths)
+    assert.equals(1, #items)
+  end)
+
+  it('keeps recursive org_directories compatibility overrides', function()
+    local directory = temp_directory()
+    local path = write_org(directory .. '/nested', 'nested.org')
+    local file = org_file(path)
+
+    config.setup({ org_directories = { directory } })
+    package.loaded['orgmode'] = { files = { load_sync = function() end } }
+    package.loaded['orgmode.api'] = {
+      load = function(requested)
+        assert.equals(vim.fn.resolve(path), requested)
+        return file
+      end,
+    }
+
+    local items = source.collect()
+
+    assert.equals(1, #items)
+    assert.equals(path, items[1].file)
+  end)
+
+  it('normalizes exclusions and respects directory boundaries', function()
+    local directory = temp_directory()
+    local excluded_path = write_org(directory .. '/work', 'private.org')
+    local included_path = write_org(directory .. '/workshop', 'public.org')
+    local files = {
+      org_file(excluded_path),
+      org_file(included_path),
+    }
+
+    config.setup({ exclude_directories = { directory .. '/work/' } })
+    package.loaded['orgmode'] = { files = { load_sync = function() end } }
+    package.loaded['orgmode.api'] = {
+      load = function()
+        return files
+      end,
+    }
+
+    local items = source.collect()
+
+    assert.equals(1, #items)
+    assert.equals(included_path, items[1].file)
+  end)
+
+  it('matches relative exclude_files against normalized filenames', function()
+    local directory = vim.fn.getcwd() .. '/tests/.tmp-source-' .. vim.fn.getpid()
+    vim.fn.mkdir(directory, 'p')
+    temp_paths[#temp_paths + 1] = directory
+    local path = write_org(directory, 'relative.org')
+    local relative_path = vim.fn.fnamemodify(path, ':.')
+
+    config.setup({ exclude_files = { relative_path } })
+    package.loaded['orgmode'] = { files = { load_sync = function() end } }
+    package.loaded['orgmode.api'] = {
+      load = function()
+        return { org_file(path) }
+      end,
+    }
+
+    local items = source.collect()
+
+    assert.equals(0, #items)
+  end)
+
+  it('matches symlinked exclusions against resolved filenames', function()
+    local directory = temp_directory()
+    local path = write_org(directory, 'real.org')
+    local link = directory .. '/linked.org'
+    local uv = vim.uv or vim.loop
+    assert.is_true(uv.fs_symlink(path, link))
+
+    config.setup({ exclude_files = { link } })
+    package.loaded['orgmode'] = { files = { load_sync = function() end } }
+    package.loaded['orgmode.api'] = {
+      load = function()
+        return { org_file(path) }
+      end,
+    }
+
+    local items = source.collect()
+
+    assert.equals(0, #items)
+  end)
+
+  it('supports the older nested orgmode api shape', function()
+    local directory = temp_directory()
+    local path = write_org(directory, 'legacy-api.org')
+    local file = org_file(path)
+
+    config.setup({ org_files = { path } })
+    package.loaded['orgmode'] = {}
+    package.loaded['orgmode.api'] = {
+      org = {
+        load = function(requested)
+          assert.equals(vim.fn.resolve(path), requested)
+          return file
+        end,
+      },
+    }
+
+    local items = source.collect()
+
+    assert.equals(1, #items)
+  end)
+end)

--- a/tests/tree_spec.lua
+++ b/tests/tree_spec.lua
@@ -1,0 +1,146 @@
+local Item = require('org-super-agenda.core.item')
+local layout_tree = require('org-super-agenda.core.layout.tree')
+
+describe('layout.tree', function()
+  local cfg = {
+    group_format = '* %s',
+    show_filename = false,
+    show_tags = false,
+    heading_max_length = 80,
+    classic = { heading_order = { 'todo', 'headline' }, short_date_labels = false, inline_dates = false },
+    tree = { show_ghost_parents = true },
+  }
+
+  local FILE = '/org/test.org'
+
+  local function anc(headline, line, todo)
+    return {
+      key = string.format('%s:%s', FILE, line),
+      headline = headline,
+      level = 1,
+      todo_state = todo,
+      file = FILE,
+      _src_line = line,
+    }
+  end
+
+  local function make(headline, line, parents, extra)
+    local o = {
+      headline = headline,
+      todo_state = 'TODO',
+      file = FILE,
+      _src_line = line,
+      parents = parents or {},
+    }
+    for k, v in pairs(extra or {}) do
+      o[k] = v
+    end
+    return Item.new(o)
+  end
+
+  local function build(items, opts)
+    local groups = { { name = 'Work', collapsed = opts and opts.collapsed or false, items = items } }
+    return layout_tree.build(groups, 80, (opts and opts.cfg) or cfg, (opts and opts.marked) or {})
+  end
+
+  it('nests a subtask under its parent', function()
+    local parent = make('Project', 1)
+    local child = make('Subtask', 2, { anc('Project', 1, 'TODO') })
+    local rows, _, line_map = build({ parent, child })
+    assert.equals('* Work (2 items)', rows[2])
+    assert.equals('  TODO Project', rows[3])
+    assert.equals('  └─ TODO Subtask', rows[4])
+    assert.equals(parent, line_map[3])
+    assert.equals(child, line_map[4])
+  end)
+
+  it('uses mid/last connectors and continuation bars', function()
+    local parent = make('Project', 1)
+    local a = make('Task A', 2, { anc('Project', 1, 'TODO') })
+    local sub = make('Sub A1', 3, { anc('Task A', 2, 'TODO'), anc('Project', 1, 'TODO') })
+    local b = make('Task B', 4, { anc('Project', 1, 'TODO') })
+    local rows = build({ parent, a, sub, b })
+    assert.equals('  TODO Project', rows[3])
+    assert.equals('  ├─ TODO Task A', rows[4])
+    assert.equals('  │  └─ TODO Sub A1', rows[5])
+    assert.equals('  └─ TODO Task B', rows[6])
+  end)
+
+  it('inserts a dimmed ghost row for a parent not in the group', function()
+    local child = make('Subtask', 5, { anc('Hidden Project', 1, nil) })
+    local rows, _, line_map = build({ child })
+    assert.equals('  Hidden Project', rows[3])
+    assert.equals('  └─ TODO Subtask', rows[4])
+    assert.is_true(line_map[3]._ghost)
+    assert.equals(FILE, line_map[3].file)
+    assert.equals(1, line_map[3]._src_line)
+  end)
+
+  it('shows the ghost todo state when the ancestor has one', function()
+    local child = make('Subtask', 5, { anc('Waiting Project', 1, 'WAITING') })
+    local rows = build({ child })
+    assert.equals('  WAITING Waiting Project', rows[3])
+  end)
+
+  it('deduplicates a shared ghost parent across siblings', function()
+    local a = make('Task A', 5, { anc('Hidden Project', 1, nil) })
+    local b = make('Task B', 6, { anc('Hidden Project', 1, nil) })
+    local rows = build({ a, b })
+    assert.equals('  Hidden Project', rows[3])
+    assert.equals('  ├─ TODO Task A', rows[4])
+    assert.equals('  └─ TODO Task B', rows[5])
+    assert.is_nil(rows[6])
+  end)
+
+  it('bridges a missing middle ancestor with a ghost under a real grandparent', function()
+    local grand = make('Grandparent', 1)
+    local child = make('Leaf', 5, { anc('Missing Parent', 3, nil), anc('Grandparent', 1, 'TODO') })
+    local rows = build({ grand, child })
+    assert.equals('  TODO Grandparent', rows[3])
+    assert.equals('  └─ Missing Parent', rows[4])
+    assert.equals('     └─ TODO Leaf', rows[5])
+  end)
+
+  it('renders items as roots when ghost parents are disabled', function()
+    local no_ghost_cfg = vim.tbl_deep_extend('force', vim.deepcopy(cfg), { tree = { show_ghost_parents = false } })
+    local child = make('Subtask', 5, { anc('Hidden Project', 1, nil) })
+    local rows = build({ child }, { cfg = no_ghost_cfg })
+    assert.equals('  TODO Subtask', rows[3])
+    assert.is_nil(rows[4])
+  end)
+
+  it('still nests under a real ancestor when ghosts are disabled', function()
+    local no_ghost_cfg = vim.tbl_deep_extend('force', vim.deepcopy(cfg), { tree = { show_ghost_parents = false } })
+    local grand = make('Grandparent', 1)
+    local child = make('Leaf', 5, { anc('Missing Parent', 3, nil), anc('Grandparent', 1, 'TODO') })
+    local rows = build({ grand, child }, { cfg = no_ghost_cfg })
+    assert.equals('  TODO Grandparent', rows[3])
+    assert.equals('  └─ TODO Leaf', rows[4])
+  end)
+
+  it('suppresses the has_more ellipsis when subtasks are visible', function()
+    local parent = make('Project', 1, nil, { has_more = true })
+    local child = make('Subtask', 2, { anc('Project', 1, 'TODO') })
+    local lonely = make('Lonely', 10, nil, { has_more = true })
+    local rows = build({ parent, child, lonely })
+    assert.equals('  TODO Project', rows[3])
+    assert.equals('  └─ TODO Subtask', rows[4])
+    assert.equals('  TODO Lonely …', rows[5])
+  end)
+
+  it('hides items and ghosts when the group is collapsed', function()
+    local child = make('Subtask', 5, { anc('Hidden Project', 1, nil) })
+    local rows, _, line_map = build({ child }, { collapsed = true })
+    assert.equals('* Work (1 item)', rows[2])
+    assert.is_nil(rows[3])
+    assert.equals('group_header', line_map[2]._kind)
+  end)
+
+  it('keeps items from different files apart', function()
+    local a = make('Task A', 1)
+    local b = Item.new({ headline = 'Task B', todo_state = 'TODO', file = '/org/other.org', _src_line = 1, parents = {} })
+    local rows = build({ a, b })
+    assert.equals('  TODO Task A', rows[3])
+    assert.equals('  TODO Task B', rows[4])
+  end)
+end)


### PR DESCRIPTION
## Summary

- Add a tree view that nests subtasks under their real org hierarchy and shows missing parents as context.
- Handle repeating tasks correctly when marking them done, including advancing repeater dates and resetting state.
- Make agenda actions more reliable across loaded buffers, swap conflicts, Windows paths, bulk prompts, and window cleanup.

Existing `org_files` and `org_directories` configurations remain supported; nvim-orgmode's `org_agenda_files` is the default for new setups.

Thanks @zhafacai for improving window cleanup in #19.

## Verification

- 149 local tests passed
- Stylua passed
- GitHub CI passed on `eb53414`
- semantic-release dry-run predicts `2.1.0`